### PR TITLE
Change the output simulator script default flags.

### DIFF
--- a/hdl/QuestaSimScript.tmpl
+++ b/hdl/QuestaSimScript.tmpl
@@ -74,7 +74,7 @@ EOF
 vlog +acc=rn -sv -nologo -quiet $GLBL
 
 if [ \$# -ge 1 ]; then
-    vsim -c -modelsimini {{ .LibDir }}/modelsim.ini {{range .Libs}}-L {{ . }} {{end}} work.board work.glbl -do \$1
+    vsim -modelsimini {{ .LibDir }}/modelsim.ini {{range .Libs}}-L {{ . }} {{end}} work.board work.glbl "\$@"
 else
     vsim -c -modelsimini {{ .LibDir }}/modelsim.ini {{range .Libs}}-L {{ . }} {{end}} work.board work.glbl -do {{ .OutSimScript }}
 fi

--- a/hdl/XSimScript.tmpl
+++ b/hdl/XSimScript.tmpl
@@ -82,7 +82,7 @@ EOF
 fi # compile"
 
 if [ \$# -ge 1 ]; then
-    xsim {{ .Name }}_sim -t \$1
+    xsim {{ .Name }}_sim "\$@"
 else
     xsim {{ .Name }}_sim -t {{ .OutSimScript }}
 fi


### PR DESCRIPTION
This enables the use of the output simulator script with non-default
arguments. Whereas the previous version only allowed running custom tcl
scripts from the command line, now we allow any custom arguments to be
passed directly to the vsim command.

- remove default -c to allow gui simulation

- Accept undefined number of arguments

Example:

- Run a batch-mode simulation (with questa):
```
./BUILD/path/to/sim/script.sh -c -do 'run -all; quit;'
```

- open a gui mode simulation, set up waveform window and run for 2000ns:
```
./BUILD/path/to/sim/script.sh -gui -do 'source
path/to/wafeform_script.do'; run 2000ns;
```

Invoking the script without arguments still starts the default
auto-generated simulation script in batch mode.