### PR TITLE
Add default include path to vlog/xvlog commands

### DIFF
--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -15,6 +15,7 @@ type QuestaSimScriptParams struct {
 	OutDir       core.Path
 	OutScript    core.Path
 	OutSimScript core.Path
+	IncDir       core.Path
 	Srcs         []core.Path
 	Ips          []core.Path
 	Libs         []string
@@ -59,6 +60,7 @@ func (rule SimulationQuesta) Build(ctx core.Context) {
 		OutDir:       outDir,
 		OutScript:    outScript,
 		OutSimScript: outSimScript,
+		IncDir:       core.SourcePath(""),
 		Srcs:         srcs,
 		Ips:          ips,
 		Libs:         rule.Libs,

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -15,6 +15,7 @@ type XSimScriptParams struct {
 	OutDir       core.Path
 	OutScript    core.Path
 	OutSimScript core.Path
+	IncDir       core.Path
 	Srcs         []core.Path
 	Ips          []core.Path
 	Libs         []string
@@ -58,6 +59,7 @@ func (rule SimulationXsim) Build(ctx core.Context) {
 		OutDir:       outDir,
 		OutScript:    outScript,
 		OutSimScript: outSimScript,
+		IncDir:       core.SourcePath(""),
 		Srcs:         srcs,
 		Ips:          ips,
 		Libs:         rule.Libs,

--- a/hdl/QuestaSimScript.tmpl
+++ b/hdl/QuestaSimScript.tmpl
@@ -8,6 +8,7 @@ set -eu -o pipefail
 {{ $partName := .PartName }}
 {{ $boardName := .BoardName }}
 {{ $verbose := .Verbose }}
+{{ $incDir := .IncDir }}
 
 rm -rf {{ .OutDir }}
 mkdir -p {{ .OutDir }}
@@ -49,7 +50,7 @@ cat > {{ .OutScript }} <<EOF
 set -eu -o pipefail
 
 vlib work
-{{ range .Srcs }}vlog +acc=rn -sv -nologo -quiet {{ . }}
+{{ range .Srcs }}vlog +acc=rn -sv -nologo -quiet +incdir+{{ $incDir }} {{ . }}
 {{ end }}
 EOF
 
@@ -59,10 +60,10 @@ EOF
     SRCS=`find {{ $outDir }}/$NAME/source -type f`
 
     for SRC in $SIM; do
-        echo "vlog +acc=rn -sv -nologo -quiet $SRC" >> {{ $outScript }}
+        echo "vlog +acc=rn -sv -nologo -quiet +incdir+{{ $incDir }} $SRC" >> {{ $outScript }}
     done
     for SRC in $SRCS; do
-        echo "vlog +acc=rn -sv -nologo -quiet $SRC" >> {{ $outScript }}
+        echo "vlog +acc=rn -sv -nologo -quiet +incdir+{{ $incDir }} $SRC" $SRC" >> {{ $outScript }}
     done
 {{end}}
 
@@ -71,7 +72,7 @@ EOF
     GLBL=`dirname $XSIMDIR`/../data/verilog/src/glbl.v
 
     cat >> {{ .OutScript }} << EOF
-vlog +acc=rn -sv -nologo -quiet $GLBL
+vlog +acc=rn -sv -nologo -quiet +incdir+{{ $incDir }} $GLBL
 
 if [ \$# -ge 1 ]; then
     vsim -c -modelsimini {{ .LibDir }}/modelsim.ini {{range .Libs}}-L {{ . }} {{end}} work.board work.glbl -do \$1

--- a/hdl/XSimScript.tmpl
+++ b/hdl/XSimScript.tmpl
@@ -8,6 +8,7 @@ set -eu -o pipefail
 {{ $partName := .PartName }}
 {{ $boardName := .BoardName }}
 {{ $verbose := .Verbose }}
+{{ $incDir := .IncDir }}
 
 rm -rf {{ .OutDir }}
 mkdir -p {{ .OutDir }}
@@ -55,7 +56,7 @@ if [ \$# -ge 1 ] && [ \$1 == "simonly" ]; then
 fi
 
 if [ \$COMPILE -eq 1 ]; then
-{{ range .Srcs }}    xvlog -work {{ $name }} --sv {{ . }}
+{{ range .Srcs }}    xvlog -work {{ $name }} --include {{ $incDir }} --sv {{ . }}
 {{ end }}
 EOF
 
@@ -65,10 +66,10 @@ EOF
     SRCS=`find {{ $outDir }}/$NAME/source -type f`
 
     for SRC in $SIM; do
-        echo "    xvlog -work {{ $name }} --sv $SRC" >> {{ $outScript }}
+        echo "    xvlog -work {{ $name }} --include {{ $incDir }} --sv $SRC" >> {{ $outScript }}
     done
     for SRC in $SRCS; do
-        echo "    xvlog -work {{ $name }} --sv $SRC" >> {{ $outScript }}
+        echo "    xvlog -work {{ $name }} --include {{ $incDir }} --sv $SRC" >> {{ $outScript }}
     done
 {{end}}
 
@@ -77,7 +78,7 @@ EOF
     GLBL=`dirname $XSIMDIR`/../data/verilog/src/glbl.v
 
     cat >> {{ .OutScript }} << EOF
-    xvlog -work {{ .Name }} $GLBL
+    xvlog -work {{ .Name }} --include {{ $incDir }} $GLBL
     xelab -initfile=$XSIMIP  --timescale 1ns/1ps -debug typical {{ .Name }}.board {{ .Name }}.glbl -s {{ .Name }}_sim -L {{ .Name }} {{range .Libs}}-L {{ . }} {{end}}
 fi # compile"
 


### PR DESCRIPTION
The default include path is set to the DEPS directory for all
projects. `include directives should always specify the include path
relative to the DEPS directory.