### PR TITLE
Register and expand toolchains, compile ccRules with multiple toolchains

### DIFF
--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -6,8 +6,6 @@ import (
 	"dbt-rules/RULES/core"
 )
 
-const objsDirSuffix = "-OBJS"
-
 // ObjectFile compiles a single C++ source file.
 type ObjectFile struct {
 	Src       core.Path
@@ -134,6 +132,9 @@ type Library struct {
 }
 
 func (lib Library) MultipleToolchains() Library {
+	if lib.Out == nil {
+		core.Fatal("Out field is required for cc.Library")
+	}
 	lib.multipleToolchains = true
 	lib.toolchainMap = make(map[string]Library)
 	lib.baseOut = lib.Out
@@ -142,6 +143,10 @@ func (lib Library) MultipleToolchains() Library {
 
 // Build a Library.
 func (lib Library) Build(ctx core.Context) {
+	if lib.Out == nil {
+		core.Fatal("Out field is required for cc.Library")
+	}
+
 	toolchain := lib.toolchain()
 
 	if lib.multipleToolchains {
@@ -232,6 +237,10 @@ type Binary struct {
 
 // Build a Binary.
 func (bin Binary) Build(ctx core.Context) {
+	if bin.Out == nil {
+		core.Fatal("Out field is required for cc.Binary")
+	}
+
 	toolchain := bin.Toolchain
 	if toolchain == nil {
 		toolchain = defaultToolchain()

--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -29,10 +29,7 @@ func (obj ObjectFile) Build(ctx core.Context) {
 }
 
 func (obj ObjectFile) out() core.OutPath {
-	toolchain := obj.Toolchain
-	if toolchain == nil {
-		toolchain = defaultToolchain()
-	}
+	toolchain := toolchainOrDefault(obj.Toolchain)
 	return obj.Src.WithPrefix(toolchain.Name() + "/").WithExt("o")
 }
 

--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -118,7 +118,7 @@ func (lib Library) Build(ctx core.Context) {
 	}
 
 	if lib.multipleToolchains {
-		if lib.Toolchain == nil {
+		if lib.Out == lib.baseOut {
 			var defaultLib = lib.WithToolchain(ctx, defaultToolchain())
 			ctx.AddBuildStep(core.BuildStep{
 				Out: lib.Out,

--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -119,12 +119,11 @@ func (lib Library) Build(ctx core.Context) {
 
 	if lib.multipleToolchains {
 		if lib.Out == lib.baseOut {
-			var defaultLib = lib.WithToolchain(ctx, defaultToolchain())
-			ctx.AddBuildStep(core.BuildStep{
-				Out: lib.Out,
-				Ins: []core.Path{defaultLib.Out},
-				Cmd: fmt.Sprintf("cp %s %s", defaultLib.Out, lib.Out),
-			})
+			var defaultLib = core.CopyFile{
+				From: lib.WithToolchain(ctx, defaultToolchain()).Out,
+				To: lib.Out,
+			}
+			defaultLib.Build(ctx)
 			return
 		}
 		if _, found := lib.toolchainMap[toolchain.Name()]; found {

--- a/RULES/cc/toolchain.go
+++ b/RULES/cc/toolchain.go
@@ -13,9 +13,10 @@ type Toolchain interface {
 	StaticLibrary(out core.Path, objs []core.Path) string
 	SharedLibrary(out core.Path, objs []core.Path) string
 	Binary(out core.Path, objs []core.Path, alwaysLinkLibs []core.Path, libs []core.Path, flags []string, script core.Path) string
-	EmbeddedBlob(out core.OutPath, src core.Path) string
+	BlobObject(out core.OutPath, src core.Path) string
 	RawBinary(out core.OutPath, elfSrc core.Path) string
 	StdDeps() []Dep
+	Script() core.Path
 }
 
 // Toolchain represents a C++ toolchain.
@@ -105,8 +106,8 @@ func (gcc GccToolchain) Binary(out core.Path, objs []core.Path, alwaysLinkLibs [
 		strings.Join(flags, " "))
 }
 
-// EmbeddedBlob creates an object file from any binary blob of data
-func (gcc GccToolchain) EmbeddedBlob(out core.OutPath, src core.Path) string {
+// BlobObject creates an object file from any binary blob of data
+func (gcc GccToolchain) BlobObject(out core.OutPath, src core.Path) string {
 	return fmt.Sprintf(
 		"%q -r -b binary -o %q %q",
 		gcc.Ld,
@@ -127,6 +128,9 @@ func (gcc GccToolchain) StdDeps() []Dep {
 	return gcc.Deps
 }
 
+func (gcc GccToolchain) Script() core.Path {
+	return gcc.LinkerScript
+}
 func (gcc GccToolchain) Name() string {
 	return gcc.ToolchainName
 }

--- a/RULES/cc/toolchain.go
+++ b/RULES/cc/toolchain.go
@@ -14,7 +14,7 @@ type Toolchain interface {
 	SharedLibrary(out core.Path, objs []core.Path) string
 	Binary(out core.Path, objs []core.Path, alwaysLinkLibs []core.Path, libs []core.Path, flags []string, script core.Path) string
 	EmbeddedBlob(out core.OutPath, src core.Path) string
-	RawBinary(out core.Path, elfSrc core.Path) string
+	RawBinary(out core.OutPath, elfSrc core.Path) string
 	StdDeps() []Dep
 }
 
@@ -115,7 +115,7 @@ func (gcc GccToolchain) EmbeddedBlob(out core.OutPath, src core.Path) string {
 }
 
 // RawBinary strips ELF metadata to create a raw binary image
-func (gcc GccToolchain) RawBinary(out core.Path, elfSrc core.Path) string {
+func (gcc GccToolchain) RawBinary(out core.OutPath, elfSrc core.Path) string {
 	return fmt.Sprintf(
 		"%q -O binary %q %q",
 		gcc.Objcopy,

--- a/RULES/cc/toolchain.go
+++ b/RULES/cc/toolchain.go
@@ -145,15 +145,15 @@ func joinQuoted(paths []core.Path) string {
 
 var toolchains = make(map[string]Toolchain)
 
-func (gcc GccToolchain) Register() Toolchain {
-	if _, found := toolchains[gcc.Name()]; found {
-		core.Fatal("A toolchain with name %s has already been registered", gcc.Name())
+func RegisterToolchain(toolchain Toolchain) Toolchain {
+	if _, found := toolchains[toolchain.Name()]; found {
+		core.Fatal("A toolchain with name %s has already been registered", toolchain.Name())
 	}
-	toolchains[gcc.Name()] = gcc
-	return gcc
+	toolchains[toolchain.Name()] = toolchain
+	return toolchain
 }
 
-var NativeGcc = GccToolchain{
+var NativeGcc = RegisterToolchain(GccToolchain{
 	Ar:      core.NewGlobalPath("ar"),
 	As:      core.NewGlobalPath("as"),
 	Cc:      core.NewGlobalPath("gcc"),
@@ -166,7 +166,7 @@ var NativeGcc = GccToolchain{
 	LinkerFlags:   []string{"-fdiagnostics-color=always"},
 
 	ToolchainName: "native-gcc",
-}.Register()
+})
 
 var defaultToolchainFlag = core.StringFlag{
 	Name:        "cc-toolchain",

--- a/RULES/cc/toolchain.go
+++ b/RULES/cc/toolchain.go
@@ -181,3 +181,10 @@ func defaultToolchain() Toolchain {
 	core.Fatal("No toolchain has been registered with the name %s", defaultToolchainFlag.Value())
 	return nil
 }
+
+func toolchainOrDefault(toolchain Toolchain) Toolchain {
+	if toolchain == nil {
+		return defaultToolchain()
+	}
+	return toolchain
+}


### PR DESCRIPTION
Made these changes:
* extended cc.Toolchain to include standard LinkerScript and standard dependencies
* reverted change in https://github.com/daedaleanai/dbt-rules/pull/12, to prevent duplicates I use the name of the toolchain instead
* registering cc.Toolchain and added flag to select one from cmdline
* cc.Library targets can be marked as for multiple toolchains, if so, when they are included as a dependency to another cc.Library or cc.Binary, they will be rebuilt using the toolchain of the cc.Library or cc.Binary that needs them. Building them directly will simply use the default toolchain (which can be set from command line flags)

To see these changes in action, see https://github.com/daedaleanai/libsupcxx/pull/14