### PR TITLE
Fix link to dbt repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository contains standard build rules for the Daedalean Build Tool (DBT).
 
-Check out the [DBT repository](github.com/daedaleanai/dbt) for details and documentation.
+Check out the [DBT repository](https://github.com/daedaleanai/dbt) for details and documentation.


### PR DESCRIPTION
The old link was relative to this repo and was broken. Maybe github changed things, I remember it working.