### PR TITLE
Revert "Compile HDL parameter packages first"

### DIFF
--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -38,7 +38,6 @@ func (rule SimulationQuesta) Build(ctx core.Context) {
 
 	ins := []core.Path{}
 	srcs := []core.Path{}
-	src_pkgs := []core.Path{}
 	ips := []core.Path{}
 
 	srcs = append(srcs, rule.Srcs...)
@@ -48,18 +47,11 @@ func (rule SimulationQuesta) Build(ctx core.Context) {
 			if strings.HasSuffix(src.String(), ".xci") {
 				ips = append(ips, src)
 			} else {
-				if strings.HasSuffix(src.String(), "_pkg.sv") ||
-					strings.HasSuffix(src.String(), "_pkg.v") {
-					src_pkgs = append(src_pkgs, src)
-				} else {
-					srcs = append(srcs, src)
-				}
+				srcs = append(srcs, src)
 			}
 			ins = append(ins, src)
 		}
 	}
-
-	srcs = append(src_pkgs, srcs...)
 
 	data := QuestaSimScriptParams{
 		PartName:     PartName.Value(),

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -37,7 +37,6 @@ func (rule SimulationXsim) Build(ctx core.Context) {
 
 	ins := []core.Path{}
 	srcs := []core.Path{}
-	src_pkgs := []core.Path{}
 	ips := []core.Path{}
 
 	srcs = append(srcs, rule.Srcs...)
@@ -47,18 +46,11 @@ func (rule SimulationXsim) Build(ctx core.Context) {
 			if strings.HasSuffix(src.String(), ".xci") {
 				ips = append(ips, src)
 			} else {
-				if strings.HasSuffix(src.String(), "_pkg.sv") ||
-					strings.HasSuffix(src.String(), "_pkg.v") {
-					src_pkgs = append(src_pkgs, src)
-				} else {
-					srcs = append(srcs, src)
-				}
+				srcs = append(srcs, src)
 			}
 			ins = append(ins, src)
 		}
 	}
-
-	srcs = append(src_pkgs, srcs...)
 
 	data := XSimScriptParams{
 		PartName:     PartName.Value(),


### PR DESCRIPTION
Reverts daedaleanai/dbt-rules#10

Obsoleted by PR #21 (Support for IP dependency graphs). Better to explicitly define the dependencies than relying on a naming convention.