### PR TITLE
dbt-rules changes for build system changes for DBTv2

### DIFF
--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -2,6 +2,7 @@ package cc
 
 import (
 	"fmt"
+	"strings"
 
 	"dbt-rules/RULES/core"
 )
@@ -254,4 +255,12 @@ func (bin Binary) Build(ctx core.Context) {
 		Cmd:   cmd,
 		Descr: fmt.Sprintf("LD (toolchain: %s) %s", toolchain.Name(), bin.Out.Relative()),
 	})
+}
+
+func (bin Binary) Run(args []string) string {
+	quotedArgs := []string{}
+	for _, arg := range args {
+		quotedArgs = append(quotedArgs, fmt.Sprintf("%q", arg))
+	}
+	return fmt.Sprintf("%q %s", bin.Out, strings.Join(quotedArgs, " "))
 }

--- a/RULES/core/context.go
+++ b/RULES/core/context.go
@@ -223,39 +223,6 @@ func (ctx *context) handleTarget(targetPath string, target buildInterface) {
 	ctx.nextRuleID++
 }
 
-func (ctx *context) finish() {
-	currentTarget = ""
-
-	// Generate the bash script
-	fmt.Fprintf(&ctx.bashFile, "#!/bin/bash\n\nset -e\n\n")
-	for out := range ctx.buildOutputs {
-		ctx.addOutputToBashScript(out)
-	}
-}
-
-func (ctx *context) addOutputToBashScript(output string) {
-	step, exists := ctx.buildOutputs[output]
-	if !exists {
-		return
-	}
-
-	for _, in := range step.ins() {
-		ctx.addOutputToBashScript(in.Absolute())
-	}
-
-	for _, out := range step.outs() {
-		delete(ctx.buildOutputs, out.Absolute())
-		fmt.Fprintf(&ctx.bashFile, "mkdir -p %q\n", path.Dir(out.Absolute()))
-	}
-
-	fmt.Fprintf(&ctx.bashFile, "echo %q\n", step.Cmd)
-	if step.Script != "" {
-		fmt.Fprintf(&ctx.bashFile, "%s\n", step.Script)
-	} else {
-		fmt.Fprintf(&ctx.bashFile, "%s\n", step.Cmd)
-	}
-}
-
 func (ctx *context) addTargetDependency(target interface{}) {
 	if reflect.TypeOf(target).Kind() != reflect.Ptr {
 		Fatal("adding target dependency to non-pointer target")

--- a/RULES/core/context.go
+++ b/RULES/core/context.go
@@ -139,10 +139,12 @@ func (ctx *context) AddBuildStep(step BuildStep) {
 		buffer := []byte(data)
 		hash := crc32.ChecksumIEEE([]byte(buffer))
 		dataFileName := fmt.Sprintf("%08X", hash)
-		dataFilePath = path.Join(buildDir(), "..", dataFileName)
-		err := ioutil.WriteFile(dataFilePath, buffer, dataFileMode)
-		if err != nil {
-			Fatal("%s", err)
+		dataFilePath = path.Join(filepath.Dir(buildDir()), "DATA", dataFileName)
+		if err := os.MkdirAll(filepath.Dir(dataFilePath), os.ModePerm); err != nil {
+			Fatal("Failed to create directory for data files: %s", err)
+		}
+		if err := ioutil.WriteFile(dataFilePath, buffer, dataFileMode); err != nil {
+			Fatal("Failed to write data file: %s", err)
 		}
 	}
 

--- a/RULES/core/flags.go
+++ b/RULES/core/flags.go
@@ -262,16 +262,8 @@ func lockAndGetFlags() map[string]flagInfo {
 }
 
 func getCmdlineFlags() map[string]string {
-	flags := map[string]string{}
-	for _, arg := range otherArgs() {
-		parts := strings.SplitN(arg, "=", 2)
-		if len(parts) > 1 {
-			flags[parts[0]] = parts[1]
-		} else {
-			flags[parts[0]] = "true"
-		}
-	}
-	return flags
+	loadInput()
+	return input.BuildFlags
 }
 
 func getConfigFileFlags() map[string]string {

--- a/RULES/core/main.go
+++ b/RULES/core/main.go
@@ -27,7 +27,6 @@ type generatorInput struct {
 type generatorOutput struct {
 	Version   uint
 	NinjaFile string
-	BashFile  string
 	Targets   map[string]targetInfo
 	Flags     map[string]flagInfo
 	BuildDir  string
@@ -66,9 +65,7 @@ func GeneratorMain(vars map[string]interface{}) {
 				ctx.handleTarget(targetPath, build)
 			}
 		}
-		ctx.finish()
 		output.NinjaFile = ctx.ninjaFile.String()
-		output.BashFile = ctx.bashFile.String()
 	}
 
 	// Serialize generator output.

--- a/RULES/core/main.go
+++ b/RULES/core/main.go
@@ -13,6 +13,7 @@ const outputFileName = "output.json"
 
 type targetInfo struct {
 	Description string
+	Runnable    bool
 }
 
 type generatorInput struct {
@@ -22,6 +23,7 @@ type generatorInput struct {
 	BuildDirPrefix  string
 	BuildFlags      map[string]string
 	CompletionsOnly bool
+	RunArgs         []string
 }
 
 type generatorOutput struct {
@@ -32,7 +34,7 @@ type generatorOutput struct {
 	BuildDir  string
 }
 
-var input generatorInput
+var input = loadInput()
 
 func GeneratorMain(vars map[string]interface{}) {
 	output := generatorOutput{
@@ -54,11 +56,14 @@ func GeneratorMain(vars map[string]interface{}) {
 		if descriptionIface, ok := variable.(descriptionInterface); ok {
 			info.Description = descriptionIface.Description()
 		}
+		if _, ok := variable.(runInterface); ok {
+			info.Runnable = true
+		}
 		output.Targets[targetPath] = info
 	}
 
 	// Create build files.
-	if !completionsOnly() {
+	if !input.CompletionsOnly {
 		ctx := newContext(vars)
 		for targetPath, variable := range vars {
 			if build, ok := variable.(buildInterface); ok {

--- a/RULES/core/path.go
+++ b/RULES/core/path.go
@@ -24,7 +24,7 @@ type inPath struct {
 
 // Absolute returns the absolute path.
 func (p inPath) Absolute() string {
-	return path.Join(sourceDir(), p.rel)
+	return path.Join(input.SourceDir, p.rel)
 }
 
 // Relative returns the path relative to the workspace source directory.
@@ -135,6 +135,7 @@ func NewGlobalPath(p string) GlobalPath {
 func BuildPath(p string) OutPath {
 	return outPath{p}
 }
+
 // SourcePath returns a path relative to the source directory.
 func SourcePath(p string) Path {
 	return inPath{p}

--- a/RULES/core/util.go
+++ b/RULES/core/util.go
@@ -19,55 +19,33 @@ var (
 	buildDirSuffix = ""
 )
 
-func completionsOnly() bool {
-	loadInput()
-	return input.CompletionsOnly
-}
-
-func sourceDir() string {
-	loadInput()
-	return input.SourceDir
-}
-
-func buildDirPrefix() string {
-	loadInput()
-	return input.BuildDirPrefix
-}
-
-func workingDir() string {
-	loadInput()
-	return input.WorkingDir
-}
-
 func buildDir() string {
 	if !flagsLocked {
 		Fatal("cannot use build directory before all flag values are known")
 	}
-	return buildDirPrefix() + buildDirSuffix
+	return input.BuildDirPrefix + buildDirSuffix
 }
 
-func loadInput() {
-	if input.Version > 0 {
-		return
-	}
-
+func loadInput() generatorInput {
 	data, err := ioutil.ReadFile(inputFileName)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Could not read input file: %s.\n", err)
+		fmt.Fprintf(os.Stderr, "Error: Could not read DBT input file: %s.\n", err)
 		os.Exit(1)
 	}
+	var input generatorInput
 	if err := json.Unmarshal(data, &input); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Could not parse input: %s.\n", err)
+		fmt.Fprintf(os.Stderr, "Error: Could not parse DBT input: %s.\n", err)
 		os.Exit(1)
 	}
 	if input.Version != buildProtocolVersion {
-		fmt.Fprintf(os.Stderr, "Error: Unexpected version of input: %d. Expected %d.\n", input.Version, buildProtocolVersion)
+		fmt.Fprintf(os.Stderr, "Error: Unexpected version of DBT input: %d. Expected %d.\n", input.Version, buildProtocolVersion)
 		os.Exit(1)
 	}
+	return input
 }
 
 func Fatal(format string, a ...interface{}) {
-	if completionsOnly() {
+	if input.CompletionsOnly {
 		return
 	}
 

--- a/RULES/util/template.go
+++ b/RULES/util/template.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"dbt-rules/RULES/core"
@@ -20,6 +21,7 @@ func (tmpl ExpandTemplate) Build(ctx core.Context) {
 	for old, new := range tmpl.Substitutions {
 		substitutions = append(substitutions, fmt.Sprintf("-e 's/%s/%s/g'", old, new))
 	}
+	sort.Strings(substitutions)
 	cmd := fmt.Sprintf("sed %s %q > %q", strings.Join(substitutions, " "), tmpl.Template, tmpl.Out)
 	ctx.AddBuildStep(core.BuildStep{
 		Out:   tmpl.Out,


### PR DESCRIPTION
dbt-rules changes for build system changes for DBTv2. Changes include:
- using a versioned protocol between DBT and the generator
- create script files in a separate `DATA` directory, not the `BUILD` directory
- hide private targets from DBT
- add `dbt run`
- no longer generate the bash file, since `ninja -t commands` gets the same thing