### PR TITLE
Fix static library command

### DIFF
--- a/RULES/cc/toolchain.go
+++ b/RULES/cc/toolchain.go
@@ -71,8 +71,16 @@ func (gcc GccToolchain) ObjectFile(out core.OutPath, depfile core.OutPath, flags
 
 // StaticLibrary generates the command to build a static library.
 func (gcc GccToolchain) StaticLibrary(out core.Path, objs []core.Path) string {
+	// ar updates an existing archive. This can cause faulty builds in the case
+	// where a symbol is defined in one file, that file is removed, and the
+	// symbol is subsequently defined in a new file. That's because the old object file
+	// can persist in the archive. See https://github.com/daedaleanai/dbt/issues/91
+	// There is no option to ar to always force creation of a new archive; the "c"
+	// modifier simply suppresses a warning if the archive doesn't already
+	// exist. So instead we delete the target (out) if it already exists.
 	return fmt.Sprintf(
-		"%q rv %q %s >/dev/null 2>/dev/null",
+		"rm %q 2>/dev/null ; %q rcs %q %s",
+		out,
 		gcc.Ar,
 		out,
 		joinQuoted(objs))


### PR DESCRIPTION
This is a fix for https://github.com/daedaleanai/dbt/issues/91

Old object files can linger in an existing archive even if they're removed from the cc.Library rule, causing inconsistent or faulty builds if a lingering .o file contains symbols that are used by current files.

The solution in this CL is to simply delete any existing archive before running the ar file. There is no option to ar to always create a new archive.

I've changed the modifiers to ar: before it was "ar rv" and now it's "ar rcs".
The "v" modifier produces verbose output, and the absence of "c" causes a warning to be produced if the archive doesn't already exist. I think with the new modifiers there's no need to pipe stdout and stderr to /dev/null.
The added "s" modifier adds an index to the archive. I think this isn't necessary with gnu ar, but maybe it's helpful for other toolchains (and very unlikely to be unhelpful).

