### PR TITLE
Improve error message when cc-toolchain is unregistered

### DIFF
--- a/RULES/cc/toolchain.go
+++ b/RULES/cc/toolchain.go
@@ -2,6 +2,7 @@ package cc
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"dbt-rules/RULES/core"
@@ -186,7 +187,12 @@ func defaultToolchain() Toolchain {
 	if toolchain, ok := toolchains[defaultToolchainFlag.Value()]; ok {
 		return toolchain
 	}
-	core.Fatal("No toolchain has been registered with the name %s", defaultToolchainFlag.Value())
+	var all []string
+	for tc, _ := range toolchains {
+		all = append(all, fmt.Sprintf("%q", tc))
+	}
+	sort.Strings(all)
+	core.Fatal("No registered toolchain %q. Registered toolchains: %s", defaultToolchainFlag.Value(), strings.Join(all, ", "))
 	return nil
 }
 


### PR DESCRIPTION
This CL improves the error message when you don't know the cc-toolchain. (It's quite difficult to find which are registered, or even what the name of the standard toolchain is). Now it lists all registered toolchains in the error mesage.

For example:

    dbt run ".*Test" cc-toolchain=native-gcx

Gives this error:

```
Error while processing target 'PROJECT_NAME_REMOVED/testing/TestMain': No registered toolchain "native-gcx". Registered toolchains: "linux-x86_64-libsupcxx", "native-gcc", "x86_64-libsupcxx".
```
