### PR TITLE
Separate toolchain-specific query and build in libraries

### DIFF
--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -121,7 +121,7 @@ type Library struct {
 
 	multipleToolchains bool
 	toolchainMap       map[string]Library
-	baseOut            core.Path
+	baseOut            core.OutPath
 }
 
 func (lib Library) MultipleToolchains() Library {

--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -200,12 +200,7 @@ func (lib Library) Build(ctx core.Context) {
 
 // CcLibrary for Library returns the library itself, or a toolchain-specific variant
 func (lib Library) CcLibrary(toolchain Toolchain) Library {
-	if toolchain == nil {
-		// This is pretty nasty, but there's no way to get the
-		// default toolchain outside of this package, so accept nil
-		// as the default toolchain.
-		toolchain = defaultToolchain()
-	}
+	toolchain = toolchainOrDefault(toolchain)
 
 	if !lib.multipleToolchains {
 		if toolchainOrDefault(lib.Toolchain).Name() != toolchain.Name() {

--- a/RULES/cc/toolchain.go
+++ b/RULES/cc/toolchain.go
@@ -2,6 +2,7 @@ package cc
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"dbt-rules/RULES/core"
@@ -186,7 +187,12 @@ func defaultToolchain() Toolchain {
 	if toolchain, ok := toolchains[defaultToolchainFlag.Value()]; ok {
 		return toolchain
 	}
-	core.Fatal("No toolchain has been registered with the name %s", defaultToolchainFlag.Value())
+	var all []string
+	for tc, _ := range toolchains {
+		all = append(all, fmt.Sprintf("%q", tc))
+	}
+	sort.Strings(all)
+	core.Fatal("No registered toolchain %q. Registered toolchains: %s", defaultToolchainFlag.Value(), strings.Join(all, ", "))
 	return nil
 }
 

--- a/RULES/core/context.go
+++ b/RULES/core/context.go
@@ -16,6 +16,9 @@ import (
 type Context interface {
 	AddBuildStep(BuildStep)
 	Cwd() OutPath
+	// Value(k) returns the value associated with the value k in the context,
+	// otherwise nil. k must be nil or be of a comparable type.
+	Value(key interface{}) interface{}
 
 	addTargetDependency(interface{})
 }
@@ -65,6 +68,35 @@ type runInterface interface {
 	Run(args []string) string
 }
 
+// kvContext is a context that acts like parent, but has
+// a key/value pair associated with it.
+type kvContext struct {
+	parent     Context
+	key, value interface{}
+}
+
+// ContextWithValue returns a new context which works like the parent context,
+// except that ctx.Value(key) will return value.
+// key must be nil or a comparable type.
+func ContextWithValue(parent Context, key, value interface{}) Context {
+	return &kvContext{parent, key, value}
+}
+
+func (kvc *kvContext) AddBuildStep(b BuildStep) {
+	kvc.parent.AddBuildStep(b)
+}
+
+func (kvc *kvContext) Cwd() OutPath {
+	return kvc.parent.Cwd()
+}
+
+func (kvc *kvContext) Value(key interface{}) {
+	if key == kvc.key {
+		return kvc.value
+	}
+	return kvc.parent.Value(key)
+}
+
 type context struct {
 	cwd                OutPath
 	targetDependencies []string
@@ -97,6 +129,11 @@ func newContext(vars map[string]interface{}) *context {
 	fmt.Fprintf(&ctx.ninjaFile, "build __phony__: phony\n\n")
 
 	return ctx
+}
+
+// There are no k/v pairs associated with a top-level context.
+func (*context) Value(k interface{}) interface{} {
+	return nil
 }
 
 // AddBuildStep adds a build step for the current target.
@@ -229,8 +266,8 @@ func (ctx *context) handleTarget(targetPath string, target buildInterface) {
 		runCmd := runIface.Run(input.RunArgs)
 		fmt.Fprintf(&ctx.ninjaFile, "rule r%d\n", ctx.nextRuleID)
 		fmt.Fprintf(&ctx.ninjaFile, "  command = %s\n", runCmd)
-                fmt.Fprintf(&ctx.ninjaFile, "  description = Running %s:\n", targetPath)
-                fmt.Fprintf(&ctx.ninjaFile, "  pool = console\n")
+		fmt.Fprintf(&ctx.ninjaFile, "  description = Running %s:\n", targetPath)
+		fmt.Fprintf(&ctx.ninjaFile, "  pool = console\n")
 		fmt.Fprintf(&ctx.ninjaFile, "\n")
 		fmt.Fprintf(&ctx.ninjaFile, "build %s#run: r%d %s __phony__\n", targetPath, ctx.nextRuleID, targetPath)
 		fmt.Fprintf(&ctx.ninjaFile, "\n")


### PR DESCRIPTION
To add toolchain-conditional rules, the code needs to query dependencies (based on the toolchain) before building them.

The existing Library rules worked, but were somewhat of a balancing-act, containing various (correct, but fragile) assumptions about what might change when the toolchain changes. They also hid code for building libraries exactly once, via the toolchainMap map.

This CL:
- collects toolchain-relevant library dependencies as a first step
- adds Context.Built(id) to help rules easily find out if they've already been built.

I also had some debugging problems so this CL also:
- adds a trace to the context, making it visible how steps get added to the ninja file (ie: top-level target // library // other_library // some object file). Currently this trace is added as a comment to the ninja file.

With these changes, a toolchain-dependent rule will be easy to add as a follow-up CL.

Note to reviewer:
This contains a non-backwards-compatible change to the rules. Previously the method for dependencies of a cc.Library was CcLibrary(), now it's CcLibrary(toolchain cc.Toolchain).
