### PR TITLE
Toolchain-specific rules

### DIFF
--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -120,16 +120,18 @@ type Library struct {
 	Toolchain     Toolchain
 }
 
-type MultipleToolchainLibrary struct {
+// multipleToolchainLibrary is a library that can be built
+// via multiple different toolchains from the same build.
+type multipleToolchainLibrary struct {
 	baseOut core.OutPath
 	lib     Library
 }
 
-func (lib Library) MultipleToolchains() MultipleToolchainLibrary {
+func (lib Library) MultipleToolchains() multipleToolchainLibrary {
 	if lib.Out == nil {
 		core.Fatal("Out field is required for cc.Library")
 	}
-	return MultipleToolchainLibrary{
+	return multipleToolchainLibrary{
 		baseOut: lib.Out,
 		lib:     lib,
 	}
@@ -137,10 +139,10 @@ func (lib Library) MultipleToolchains() MultipleToolchainLibrary {
 
 // CcLibrary for a multi-toolchain-library returns a toolchain-specific
 // copy of the registered library.
-func (mtl MultipleToolchainLibrary) CcLibrary(toolchain Toolchain) Library {
+func (mtl multipleToolchainLibrary) CcLibrary(toolchain Toolchain) Library {
 	toolchain = toolchainOrDefault(toolchain)
 	tcLib := mtl.lib
-	if toolchain.Name() != defaultToolchain().Name() {
+	if toolchain.Name() != DefaultToolchain().Name() {
 		tcLib.Out = mtl.baseOut.WithPrefix(toolchain.Name() + "/")
 	}
 	tcLib.Toolchain = toolchain
@@ -149,8 +151,8 @@ func (mtl MultipleToolchainLibrary) CcLibrary(toolchain Toolchain) Library {
 
 // Build for a multi-toolchain-library builds the library
 // with the default toolchain.
-func (mtl MultipleToolchainLibrary) Build(ctx core.Context) {
-	mtl.CcLibrary(defaultToolchain()).Build(ctx)
+func (mtl multipleToolchainLibrary) Build(ctx core.Context) {
+	mtl.CcLibrary(DefaultToolchain()).Build(ctx)
 }
 
 // Build a Library.

--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -118,20 +118,39 @@ type Library struct {
 	Shared        bool
 	AlwaysLink    bool
 	Toolchain     Toolchain
-
-	multipleToolchains bool
-	toolchainMap       map[string]Library
-	baseOut            core.OutPath
 }
 
-func (lib Library) MultipleToolchains() Library {
+type MultipleToolchainLibrary struct {
+	baseOut core.OutPath
+	lib     Library
+}
+
+func (lib Library) MultipleToolchains() MultipleToolchainLibrary {
 	if lib.Out == nil {
 		core.Fatal("Out field is required for cc.Library")
 	}
-	lib.multipleToolchains = true
-	lib.toolchainMap = make(map[string]Library)
-	lib.baseOut = lib.Out
-	return lib
+	return MultipleToolchainLibrary{
+		baseOut: lib.Out,
+		lib:     lib,
+	}
+}
+
+// CcLibrary for a multi-toolchain-library returns a toolchain-specific
+// copy of the registered library.
+func (mtl MultipleToolchainLibrary) CcLibrary(toolchain Toolchain) Library {
+	toolchain = toolchainOrDefault(toolchain)
+	tcLib := mtl.lib
+	if toolchain.Name() != defaultToolchain().Name() {
+		tcLib.Out = mtl.baseOut.WithPrefix(toolchain.Name() + "/")
+	}
+	tcLib.Toolchain = toolchain
+	return tcLib
+}
+
+// Build for a multi-toolchain-library builds the library
+// with the default toolchain.
+func (mtl MultipleToolchainLibrary) Build(ctx core.Context) {
+	mtl.CcLibrary(defaultToolchain()).Build(ctx)
 }
 
 // Build a Library.
@@ -145,23 +164,6 @@ func (lib Library) build(ctx core.Context) {
 	}
 
 	toolchain := toolchainOrDefault(lib.Toolchain)
-
-	if lib.multipleToolchains {
-		if lib.Out == lib.baseOut {
-			tclib := lib.CcLibrary(defaultToolchain())
-			tclib.Build(ctx)
-			var defaultLib = core.CopyFile{
-				From: tclib.Out,
-				To:   lib.Out,
-			}
-			defaultLib.Build(ctx)
-			return
-		}
-		if _, found := lib.toolchainMap[toolchain.Name()]; found {
-			return
-		}
-		lib.toolchainMap[toolchain.Name()] = lib
-	}
 
 	deps := collectDepsWithToolchain(toolchain, append(toolchain.StdDeps(), lib))
 	for _, d := range deps {
@@ -202,19 +204,10 @@ func (lib Library) Build(ctx core.Context) {
 func (lib Library) CcLibrary(toolchain Toolchain) Library {
 	toolchain = toolchainOrDefault(toolchain)
 
-	if !lib.multipleToolchains {
-		if toolchainOrDefault(lib.Toolchain).Name() != toolchain.Name() {
-			core.Fatal("Library %s does not support toolchain %s", lib.Out.Relative(), toolchain.Name())
-		}
-		return lib
+	if toolchainOrDefault(lib.Toolchain).Name() != toolchain.Name() {
+		core.Fatal("Library %s does not support toolchain %s", lib.Out.Relative(), toolchain.Name())
 	}
-	if otherLib, found := lib.toolchainMap[toolchain.Name()]; found {
-		return otherLib
-	}
-	otherLib := lib
-	otherLib.Out = lib.baseOut.WithPrefix(toolchain.Name() + "/")
-	otherLib.Toolchain = toolchain
-	return otherLib
+	return lib
 }
 
 // Binary builds and links an executable.

--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -121,7 +121,7 @@ type Library struct {
 
 	multipleToolchains bool
 	toolchainMap       map[string]Library
-	baseOut            core.Path
+	baseOut            core.OutPath
 }
 
 func (lib Library) MultipleToolchains() Library {

--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -200,12 +200,7 @@ func (lib Library) Build(ctx core.Context) {
 
 // CcLibrary for Library returns the library itself, or a toolchain-specific variant
 func (lib Library) CcLibrary(toolchain Toolchain) Library {
-	if toolchain == nil {
-		// This is pretty nasty, but there's no way to get the
-		// default toolchain outside of this package, so accept nil
-		// as the default toolchain.
-		toolchain = defaultToolchain()
-	}
+	toolchain = toolchainOrDefault(toolchain)
 
 	if !lib.multipleToolchains {
 		if toolchainOrDefault(lib.Toolchain).Name() != toolchain.Name() {

--- a/RULES/cc/condtoolchain.go
+++ b/RULES/cc/condtoolchain.go
@@ -1,0 +1,20 @@
+package cc
+
+import "dbt-rules/RULES/core"
+
+// CondToolchainLibrary is a library that can vary based on the toolchain.
+// Use:
+// var MyLib = CondToolchainLibrary(func(tc cc.Toolchain) Library {
+//   .. test features of toolchain and return Library
+// })
+type CondToolchainLibrary func(tc Toolchain) Library
+
+// CcLibrary returns the toolchain-specific library.
+func (ctl CondToolchainLibrary) CcLibrary(tc Toolchain) Library {
+	return ctl(tc)
+}
+
+// Build builds the library with the default toolchain.
+func (ctl CondToolchainLibrary) Build(ctx core.Context) {
+	ctl(DefaultToolchain()).Build(ctx)
+}

--- a/RULES/cc/toolchain.go
+++ b/RULES/cc/toolchain.go
@@ -2,6 +2,7 @@ package cc
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"dbt-rules/RULES/core"
@@ -186,7 +187,12 @@ func defaultToolchain() Toolchain {
 	if toolchain, ok := toolchains[defaultToolchainFlag.Value()]; ok {
 		return toolchain
 	}
-	core.Fatal("No toolchain has been registered with the name %s", defaultToolchainFlag.Value())
+	var all []string
+	for tc, _ := range toolchains {
+		all = append(all, fmt.Sprintf("%q", tc))
+	}
+	sort.Strings(all)
+	core.Fatal("No registered toolchain %q. Registered toolchains: %s", defaultToolchainFlag.Value(), strings.Join(all, ", "))
 	return nil
 }
 

--- a/RULES/core/context.go
+++ b/RULES/core/context.go
@@ -16,6 +16,9 @@ import (
 type Context interface {
 	AddBuildStep(BuildStep)
 	Cwd() OutPath
+	// Value(k) returns the value associated with the value k in the context,
+	// otherwise nil. k must be nil or be of a comparable type.
+	Value(key interface{}) interface{}
 
 	addTargetDependency(interface{})
 }
@@ -65,6 +68,35 @@ type runInterface interface {
 	Run(args []string) string
 }
 
+// kvContext is a context that acts like parent, but has
+// a key/value pair associated with it.
+type kvContext struct {
+	parent     Context
+	key, value interface{}
+}
+
+// ContextWithValue returns a new context which works like the parent context,
+// except that ctx.Value(key) will return value.
+// key must be nil or a comparable type.
+func ContextWithValue(parent Context, key, value interface{}) Context {
+	return &kvContext{parent, key, value}
+}
+
+func (kvc *kvContext) AddBuildStep(b BuildStep) {
+	kvc.parent.AddBuildStep(b)
+}
+
+func (kvc *kvContext) Cwd() OutPath {
+	return kvc.parent.Cwd()
+}
+
+func (kvc *kvContext) Value(key interface{}) {
+	if key == kvc.key {
+		return kvc.value
+	}
+	return kvc.parent.Value(key)
+}
+
 type context struct {
 	cwd                OutPath
 	targetDependencies []string
@@ -97,6 +129,11 @@ func newContext(vars map[string]interface{}) *context {
 	fmt.Fprintf(&ctx.ninjaFile, "build __phony__: phony\n\n")
 
 	return ctx
+}
+
+// There are no k/v pairs associated with a top-level context.
+func (*context) Value(k interface{}) interface{} {
+	return nil
 }
 
 // AddBuildStep adds a build step for the current target.
@@ -229,8 +266,8 @@ func (ctx *context) handleTarget(targetPath string, target buildInterface) {
 		runCmd := runIface.Run(input.RunArgs)
 		fmt.Fprintf(&ctx.ninjaFile, "rule r%d\n", ctx.nextRuleID)
 		fmt.Fprintf(&ctx.ninjaFile, "  command = %s\n", runCmd)
-                fmt.Fprintf(&ctx.ninjaFile, "  description = Running %s:\n", targetPath)
-                fmt.Fprintf(&ctx.ninjaFile, "  pool = console\n")
+		fmt.Fprintf(&ctx.ninjaFile, "  description = Running %s:\n", targetPath)
+		fmt.Fprintf(&ctx.ninjaFile, "  pool = console\n")
 		fmt.Fprintf(&ctx.ninjaFile, "\n")
 		fmt.Fprintf(&ctx.ninjaFile, "build %s#run: r%d %s __phony__\n", targetPath, ctx.nextRuleID, targetPath)
 		fmt.Fprintf(&ctx.ninjaFile, "\n")


### PR DESCRIPTION
This CL extracts the multiple-toolchain feature of Libraries into its own struct (making things a little simpler I think).
It also adds a toolchain-conditional library where you can write a function that takes a toolchain and returns a Library.

This CL is a follow-up to https://github.com/daedaleanai/dbt-rules/pull/37 . There's probably some way to show this CL as a diff from that pull request, but I didn't figure it out.
