### PR TITLE
Fix map randomness issues when pattern matching board names to customizations

### DIFF
--- a/RULES/core/util.go
+++ b/RULES/core/util.go
@@ -123,3 +123,13 @@ func GetSortedOutPaths(pathMap map[string]OutPath) []OutPath {
 	}
 	return paths
 }
+
+type StringPath struct {
+	Key   string
+	Value Path
+}
+
+type StringString struct {
+	Key   string
+	Value string
+}

--- a/RULES/xilinx/device_tree.go
+++ b/RULES/xilinx/device_tree.go
@@ -56,7 +56,7 @@ type DeviceTree struct {
 	Ip Ip
 
 	// A map of board specific source tree overrides. Go-style regexp are accepted, including `.*`.
-	BoardDts map[string]core.Path
+	BoardDts []core.StringPath
 }
 
 func (rule DeviceTree) Build(ctx core.Context) {
@@ -74,13 +74,13 @@ func (rule DeviceTree) Build(ctx core.Context) {
 
 	var boardDts core.Path
 	board := hdl.BoardName.Value()
-	for pattern, dtsPath := range rule.BoardDts {
-		matched, err := regexp.MatchString(pattern, board)
+	for _, cfg := range rule.BoardDts {
+		matched, err := regexp.MatchString(cfg.Key, board)
 		if err != nil {
 			core.Fatal("Board DTS: %s", err)
 		}
 		if matched {
-			boardDts = dtsPath
+			boardDts = cfg.Value
 		}
 	}
 

--- a/RULES/xilinx/handoff.go
+++ b/RULES/xilinx/handoff.go
@@ -63,7 +63,7 @@ type Handoff struct {
 	Ip Ip
 
 	// Platform-specific patches to be applied, if any. Go-style regexps are accepted.
-	Patches map[string]core.Path
+	Patches []core.StringPath
 }
 
 func (rule Handoff) Build(ctx core.Context) {
@@ -81,13 +81,13 @@ func (rule Handoff) Build(ctx core.Context) {
 
 	var patch core.Path
 	board := hdl.BoardName.Value()
-	for pattern, patchPath := range rule.Patches {
-		matched, err := regexp.MatchString(pattern, board)
+	for _, cfg := range rule.Patches {
+		matched, err := regexp.MatchString(cfg.Key, board)
 		if err != nil {
 			core.Fatal("Handoff patch: %s", err)
 		}
 		if matched {
-			patch = patchPath
+			patch = cfg.Value
 		}
 	}
 

--- a/RULES/xilinx/uboot.go
+++ b/RULES/xilinx/uboot.go
@@ -34,28 +34,19 @@ type UBoot struct {
 	Out core.OutPath
 
 	// Map of board names to U-Boot configurations. Go-style regexps accepted.
-	Configs map[string]string
+	Configs []core.StringString
 }
 
 func (rule UBoot) Build(ctx core.Context) {
 	var config string
 	board := hdl.BoardName.Value()
-	for pattern, cfg := range rule.Configs {
-		if pattern == ".*" {
-			continue
-		}
-		matched, err := regexp.MatchString(pattern, board)
+	for _, cfg := range rule.Configs {
+		matched, err := regexp.MatchString(cfg.Key, board)
 		if err != nil {
 			core.Fatal("UBoot config: %s", err)
 		}
 		if matched {
-			config = cfg
-		}
-	}
-
-	if config == "" {
-		if cfg, ok := rule.Configs[".*"]; ok {
-			config = cfg
+			config = cfg.Value
 		}
 	}
 


### PR DESCRIPTION
Go maps are traversed in random order. This causes issues when keys contain wildcards matching multiple boards.

Fixes #31 