### PR TITLE
Corrections and extension to synthesis script

### DIFF
--- a/RULES/xilinx/synth_out_of_context.go
+++ b/RULES/xilinx/synth_out_of_context.go
@@ -5,7 +5,6 @@ import (
 	"dbt-rules/RULES/hdl"
 	h "dbt-rules/hdl"
 	"fmt"
-	"time"
 )
 
 type ConstraintsFileScriptParams struct {
@@ -54,6 +53,7 @@ func (rule SynthOutOfContext) Build(ctx core.Context) {
 		}
 	}
 
+	// Default parameters
 	clockSignal := "clk_i"
 	clockPeriod := float32(1.550)
 
@@ -90,22 +90,22 @@ func (rule SynthOutOfContext) Build(ctx core.Context) {
 
 	outBf := ctx.Cwd().WithSuffix("/" + rule.Name + "_synth.tcl")
 
-	// Flow reports and checkpoints are saved in a timestamped directory in PROJECT_ROOT/synth_reports.
-	currentTime := time.Now().Format("2006-01-02--15-04")
-	outReportDir := core.SourcePath("../synth_reports/" + rule.Name + "/" + currentTime)
+	// Base directory for timestamped flow reports and checkpoints (PROJECT_ROOT/synth_reports/name)
+	outReportDir := core.SourcePath("../synth_reports/" + rule.Name)
 
 	bfData := BuildFileScriptParams{
-		Out:          outBf,
-		Name:         rule.Name,
-		OutOfContext: true,
-		PartName:     hdl.PartName.Value(),
-		BoardName:    hdl.BoardName.Value(),
-		BoardFiles:   rule.BoardFiles,
-		IncDir:       core.SourcePath(""),
-		Ips:          ips,
-		Rtls:         rtls,
-		Constrs:      constrs,
-		ReportDir:    outReportDir,
+		Out:             outBf,
+		Name:            rule.Name,
+		OutOfContext:    true,
+		PartName:        hdl.PartName.Value(),
+		BoardName:       hdl.BoardName.Value(),
+		BoardFiles:      rule.BoardFiles,
+		IncDir:          core.SourcePath(""),
+		Ips:             ips,
+		Rtls:            rtls,
+		Constrs:         constrs,
+		ReportDir:       outReportDir,
+		FlattenStrategy: SynthFlattenStrategy.Value(),
 	}
 
 	ctx.AddBuildStep(core.BuildStep{

--- a/hdl/XilinxBuildScript.tmpl
+++ b/hdl/XilinxBuildScript.tmpl
@@ -4,96 +4,121 @@ set -eu -o pipefail
 {{ $outOfContext := .OutOfContext }}
 
 cat > {{ .Out }} <<EOF
-{{range .BoardFiles}}
-set_param board.repoPaths [lappend board.repoPaths "{{ . }}"]
-{{end}}
 
-set_part "{{ .PartName }}"
-set_property "target_language"    "Verilog"        [current_project]
+# Result folders
+set current_time [clock format [clock seconds] -format "%y-%m-%d--%H-%M"]
+set out_path "{{ .ReportDir }}/\$current_time"
 
-{{ if not .OutOfContext }}
-	set_property "board_part"         "{{ .BoardName}}"       [current_project]
-{{ end }}
+exec mkdir -p \$out_path
+exec mkdir -p \$out_path/checkpoints
 
-proc generate_reports {report_dir} {
-	# Timing
-	report_timing -from [all_registers -output_pins] -to [all_registers -data_pins] -max_paths 50 > \$report_dir/datapath_tss.rpt
-	report_timing -from [all_inputs] -to [all_registers -data_pins] -max_paths 50 > \$report_dir/datapath_tis.rpt
-	report_timing -from [all_registers -output_pins] -to [all_outputs] -max_paths 50 > \$report_dir/datapath_tso.rpt
-	report_timing -from [all_inputs] -to [all_outputs] -max_paths 50 > \$report_dir/datapath_tio.rpt
-	report_timing_summary > \$report_dir/timing_summary.rpt
+proc main {out_path} {
 
-	# Design analysis
-	report_design_analysis -extend -setup -congestion -complexity -timing -file \$report_dir/design_analysis.rpt
-	report_pipeline_analysis -file \$report_dir/pipeline_analysis.rpt
+	{{range .BoardFiles}}
+	set_param board.repoPaths [lappend board.repoPaths "{{ . }}"]
+	{{end}}
 
-	# Utilization
-	report_utilization -hierarchical_depth 4 -hierarchical > \$report_dir/util_hierarchical.rpt
-	report_utilization > \$report_dir/util_summary.rpt
+	set_part "{{ .PartName }}"
+	set_property "target_language"    "Verilog"        [current_project]
+
+	{{ if not .OutOfContext }}
+		set_property "board_part"         "{{ .BoardName}}"       [current_project]
+	{{ end }}
+
+	# Number of timing paths to report
+	set npaths 10
+
+	proc generate_reports {path {npaths 10}} {
+		# Timing
+		report_timing -from [all_registers -output_pins] -to [all_registers -data_pins] -max_paths \$npaths > \$path/datapath_tss.rpt
+		report_timing -from [all_inputs] -to [all_registers -data_pins] -max_paths \$npaths > \$path/datapath_tis.rpt
+		report_timing -from [all_registers -output_pins] -to [all_outputs] -max_paths \$npaths > \$path/datapath_tso.rpt
+		report_timing -from [all_inputs] -to [all_outputs] -max_paths \$npaths > \$path/datapath_tio.rpt
+		report_timing_summary > \$path/timing_summary.rpt
+
+		# Design analysis
+		report_design_analysis -extend -setup -congestion -complexity -timing -file \$path/design_analysis.rpt
+		report_pipeline_analysis -file \$path/pipeline_analysis.rpt
+
+		# Utilization
+		report_utilization -hierarchical_depth 4 -hierarchical > \$path/util_hierarchical.rpt
+		report_utilization > \$path/util_summary.rpt
+	}
+
+	puts "INFO: ([clock format [clock seconds] -format %H:%M:%S]) Reading source code..."
+	{{ range .Ips }}
+	set path "{{ . }}"
+	set normalized [file normalize [string range \$path 1 [string length \$path]]]
+	set dir [file join [pwd] [file dirname \$normalized]]
+	set filename [file tail \$normalized]
+	file mkdir \$dir
+	file copy "{{ . }}" \$dir
+	set ip [file join \$dir \$filename]
+	read_ip \$ip
+	generate_target all [get_files \$ip]
+	set_property GENERATE_SYNTH_CHECKPOINT true [get_files \$ip]
+	synth_ip [get_files \$ip]
+	{{ end }}
+
+	report_ip_status
+
+	{{ range .Rtls }}
+	    {{ if hasSuffix .String ".vhd" }}
+		read_vhdl "{{ . }}"
+	    {{ else }}
+		read_verilog -sv "{{ . }}"
+	    {{ end }}
+	{{ end }}
+
+	puts "INFO: ([clock format [clock seconds] -format %H:%M:%S]) Reading constraints..."
+	{{ range .Constrs }}
+		read_xdc {{ if $outOfContext }} -mode out_of_context {{ end }} "{{ . }}"
+	{{ end }}
+
+
+	puts "INFO: ([clock format [clock seconds] -format %H:%M:%S]) Running synthesis..."
+	synth_design -top {{ .Name }} -include_dirs {{ .IncDir }} {{ if .OutOfContext }} -mode out_of_context {{ end }} -flatten_hierarchy {{ .FlattenStrategy }} > \$out_path/synth.log
+	write_checkpoint -force \$out_path/checkpoints/post_synth
+	exec mkdir -p \$out_path/post_synth
+	generate_reports \$out_path/post_synth
+
+	opt_design > \$out_path/opt.log
+	write_checkpoint -force \$out_path/checkpoints/post_opt
+	exec mkdir -p \$out_path/post_opt
+	generate_reports \$out_path/post_opt
+
+	puts "INFO: ([clock format [clock seconds] -format %H:%M:%S]) Running placement..."
+	place_design > \$out_path/place.log
+	write_checkpoint -force \$out_path/checkpoints/post_place
+	exec mkdir -p \$out_path/post_place
+	generate_reports \$out_path/post_place
+
+	phys_opt_design > \$out_path/phys_opt.log
+	write_checkpoint -force \$out_path/checkpoints/post_phys_opt
+	exec mkdir -p \$out_path/post_phys_opt
+	generate_reports \$out_path/post_phys_opt
+
+	puts "INFO: ([clock format [clock seconds] -format %H:%M:%S]) Running routing..."
+	route_design > \$out_path/route.log
+	write_checkpoint -force \$out_path/checkpoints/post_route
+	exec mkdir -p \$out_path/post_route
+	generate_reports \$out_path/post_route
+
+	{{ if not .OutOfContext }}
+		write_bitstream -force bitstream.bit
+		write_debug_probes -force bitstream.ltx
+	{{ end }}
 }
 
-# Set Results folder
+if {[catch {main \$out_path}]} {
+	set status 1
+	puts "ERROR: ([clock format [clock seconds] -format %H:%M:%S]) Run failed."
+	puts "INFO: Report directory: \$out_path"
+} else {
+	set status 0
+	puts "INFO: ([clock format [clock seconds] -format %H:%M:%S]) Run successful."
+	puts "INFO: Report directory: \$out_path"
+}
+exit \$status
 
-set OUT_CHECKPOINTS "{{ .ReportDir }}/checkpoints"
-
-exec mkdir -p {{ .ReportDir }}
-exec mkdir -p \$OUT_CHECKPOINTS
-
-{{ range .Ips }}
-set path "{{ . }}"
-set normalized [file normalize [string range \$path 1 [string length \$path]]]
-set dir [file join [pwd] [file dirname \$normalized]]
-set filename [file tail \$normalized]
-file mkdir \$dir
-file copy "{{ . }}" \$dir
-set ip [file join \$dir \$filename]
-read_ip \$ip
-generate_target all [get_files \$ip]
-set_property GENERATE_SYNTH_CHECKPOINT true [get_files \$ip]
-synth_ip [get_files \$ip]
-{{ end }}
-
-report_ip_status
-
-{{ range .Rtls }}
-    {{ if hasSuffix .String ".vhd" }}
-        read_vhdl "{{ . }}"
-    {{ else }}
-        read_verilog -sv "{{ . }}"
-    {{ end }}
-{{ end }}
-
-{{ range .Constrs }}
-	read_xdc {{ if $outOfContext }} -mode out_of_context {{ end }} "{{ . }}"
-{{ end }}
-
-synth_design -top {{ .Name }} -include_dirs {{ .IncDir }} {{ if .OutOfContext }} -mode out_of_context {{ end }} -flatten_hierarchy rebuilt > {{ .ReportDir }}/synth.log
-write_checkpoint -force \$OUT_CHECKPOINTS/post_synth
-exec mkdir -p {{ .ReportDir }}/post_synth
-generate_reports {{ .ReportDir }}/post_synth
-
-opt_design > {{ .ReportDir }}/opt.log
-write_checkpoint -force \$OUT_CHECKPOINTS/post_opt
-exec mkdir -p {{ .ReportDir }}/post_opt
-generate_reports {{ .ReportDir }}/post_opt
-
-place_design > {{ .ReportDir }}/place.log
-write_checkpoint -force \$OUT_CHECKPOINTS/post_place
-exec mkdir -p {{ .ReportDir }}/post_place
-generate_reports {{ .ReportDir }}/post_place
-
-phys_opt_design > {{ .ReportDir }}/phys_opt.log
-write_checkpoint -force \$OUT_CHECKPOINTS/post_phys_opt
-exec mkdir -p {{ .ReportDir }}/post_phys_opt
-generate_reports {{ .ReportDir }}/post_phys_opt
-
-route_design > {{ .ReportDir }}/route.log
-write_checkpoint -force \$OUT_CHECKPOINTS/post_route
-exec mkdir -p {{ .ReportDir }}/post_route
-generate_reports {{ .ReportDir }}/post_route
-
-{{ if not .OutOfContext }}
-	write_bitstream -force bitstream.bit
-	write_debug_probes -force bitstream.ltx
-{{ end }}
 EOF


### PR DESCRIPTION
This change affects the bitstream and synth_out_of_context targets:

- Generate timestamped report folder name at run-time not at
  script-generation time
- Add end-of-run message, containing report folder regardless if the run
  succeeds
- Add target parameter SynthFlattenStrategy. Chose synthesis-time
  hierarchy flattening strategy (none, rebuilt, full)