### PR TITLE
Make cc.Library multitoolchain by default

### DIFF
--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -60,29 +60,28 @@ func (blob BlobObject) out() core.OutPath {
 	return blob.In.WithPrefix(toolchain.Name() + "/").WithExt("blob.o")
 }
 
-func collectDepsWithToolchainRec(toolchain Toolchain, deps []Dep, visited map[string]bool) []Library {
-	var flatDeps []Library
+func collectDepsWithToolchainRec(toolchain Toolchain, deps []Dep, visited map[string]bool) []Dep {
+	var flatDeps []Dep
 	for _, dep := range deps {
-		lib := dep.CcLibrary(toolchain)
-
-		libPath := lib.Out.Absolute()
-		if !visited[libPath] {
-			visited[libPath] = true
-			flatDeps = append(flatDeps, lib)
-			flatDeps = append(flatDeps, collectDepsWithToolchainRec(toolchain, lib.Deps, visited)...)
+		dep = dep.WithToolchain(toolchain)
+		depPath := dep.GetBuildOut().Absolute()
+		if !visited[depPath] {
+			visited[depPath] = true
+			flatDeps = append(flatDeps, dep)
+			flatDeps = append(flatDeps, collectDepsWithToolchainRec(toolchain, dep.GetDirectDeps(), visited)...)
 		}
 	}
 	return flatDeps
 }
 
-func collectDepsWithToolchain(toolchain Toolchain, deps []Dep) []Library {
+func collectDepsWithToolchain(toolchain Toolchain, deps []Dep) []Dep {
 	return collectDepsWithToolchainRec(toolchain, deps, map[string]bool{})
 }
 
-func compileSources(ctx core.Context, srcs []core.Path, flags []string, deps []Library, toolchain Toolchain) []core.Path {
+func compileSources(ctx core.Context, srcs []core.Path, flags []string, deps []Dep, toolchain Toolchain) []core.Path {
 	includes := []core.Path{core.SourcePath("")}
 	for _, dep := range deps {
-		includes = append(includes, dep.Includes...)
+		includes = append(includes, dep.GetIncludes()...)
 	}
 
 	objs := []core.Path{}
@@ -101,9 +100,20 @@ func compileSources(ctx core.Context, srcs []core.Path, flags []string, deps []L
 	return objs
 }
 
-// Dep is an interface implemented by dependencies that can be linked into a library.
+// Dep is an interface implemented by dependencies that can be linked into a binary/library.
 type Dep interface {
-	CcLibrary(toolchain Toolchain) Library
+	// Returns a new instance of Dep which will be build using the specified toolchain.
+	WithToolchain(toolchain Toolchain) Dep
+
+	Build(ctx core.Context)
+	GetDirectDeps() []Dep
+
+	// Returns the build path of Dep, i.e., the exact path where DBT will emit the Dep.
+	// Note that this might differ from the user-specified "Out" path, for example if non-default toolchain is used.
+	GetBuildOut() core.OutPath
+
+	GetIncludes() []core.Path
+	IsAlwaysLink() bool
 }
 
 // Library builds and links a static C++ library.
@@ -120,48 +130,14 @@ type Library struct {
 	Toolchain     Toolchain
 }
 
-// multipleToolchainLibrary is a library that can be built
-// via multiple different toolchains from the same build.
-type multipleToolchainLibrary struct {
-	baseOut core.OutPath
-	lib     Library
-}
-
-func (lib Library) MultipleToolchains() multipleToolchainLibrary {
-	if lib.Out == nil {
-		core.Fatal("Out field is required for cc.Library")
-	}
-	return multipleToolchainLibrary{
-		baseOut: lib.Out,
-		lib:     lib,
-	}
-}
-
-// CcLibrary for a multi-toolchain-library returns a toolchain-specific
-// copy of the registered library.
-func (mtl multipleToolchainLibrary) CcLibrary(toolchain Toolchain) Library {
-	toolchain = toolchainOrDefault(toolchain)
-	tcLib := mtl.lib
-	if toolchain.Name() != DefaultToolchain().Name() {
-		tcLib.Out = mtl.baseOut.WithPrefix(toolchain.Name() + "/")
-	}
-	tcLib.Toolchain = toolchain
-	return tcLib
-}
-
-// Build for a multi-toolchain-library builds the library
-// with the default toolchain.
-func (mtl multipleToolchainLibrary) Build(ctx core.Context) {
-	mtl.CcLibrary(DefaultToolchain()).Build(ctx)
-}
-
 // Build a Library.
 func (lib Library) build(ctx core.Context) {
 	if lib.Out == nil {
 		core.Fatal("Out field is required for cc.Library")
 	}
 
-	if ctx.Built(lib.Out.Absolute()) {
+	buildOut := lib.GetBuildOut()
+	if ctx.Built(buildOut.Absolute()) {
 		return
 	}
 
@@ -183,15 +159,15 @@ func (lib Library) build(ctx core.Context) {
 
 	var cmd, descr string
 	if lib.Shared {
-		cmd = toolchain.SharedLibrary(lib.Out, objs)
-		descr = fmt.Sprintf("LD (toolchain: %s) %s", toolchain.Name(), lib.Out.Relative())
+		cmd = toolchain.SharedLibrary(buildOut, objs)
+		descr = fmt.Sprintf("LD (toolchain: %s) %s", toolchain.Name(), buildOut.Relative())
 	} else {
-		cmd = toolchain.StaticLibrary(lib.Out, objs)
-		descr = fmt.Sprintf("AR (toolchain: %s) %s", toolchain.Name(), lib.Out.Relative())
+		cmd = toolchain.StaticLibrary(buildOut, objs)
+		descr = fmt.Sprintf("AR (toolchain: %s) %s", toolchain.Name(), buildOut.Relative())
 	}
 
 	ctx.AddBuildStep(core.BuildStep{
-		Out:   lib.Out,
+		Out:   buildOut,
 		Ins:   objs,
 		Cmd:   cmd,
 		Descr: descr,
@@ -199,17 +175,36 @@ func (lib Library) build(ctx core.Context) {
 }
 
 func (lib Library) Build(ctx core.Context) {
-	ctx.WithTrace("lib:"+lib.Out.Relative(), lib.build)
+	ctx.WithTrace("lib:"+lib.GetBuildOut().Relative(), lib.build)
 }
 
-// CcLibrary for Library returns the library itself, or a toolchain-specific variant
-func (lib Library) CcLibrary(toolchain Toolchain) Library {
-	toolchain = toolchainOrDefault(toolchain)
-
-	if !ToolchainAccepts(toolchain, toolchainOrDefault(lib.Toolchain)) {
-		core.Fatal("Library %s does not support toolchain %s", lib.Out.Relative(), toolchain.Name())
+// Returns a toolchain-specific variant of the Library.
+func (lib Library) WithToolchain(toolchain Toolchain) Dep {
+	if toolchain == nil {
+		core.Fatal("Using Library without toolchain is illegal (%s)", lib.GetBuildOut())
 	}
+	lib.Toolchain = toolchain
 	return lib
+}
+
+func (lib Library) GetDirectDeps() []Dep {
+	return lib.Deps
+}
+
+func (lib Library) GetBuildOut() core.OutPath {
+	if lib.Toolchain == nil || lib.Toolchain.Name() == DefaultToolchain().Name() {
+		return lib.Out
+	}
+
+	return lib.Out.WithPrefix(lib.Toolchain.Name() + "/")
+}
+
+func (lib Library) GetIncludes() []core.Path {
+	return lib.Includes
+}
+
+func (lib Library) IsAlwaysLink() bool {
+	return lib.AlwaysLink
 }
 
 // Binary builds and links an executable.
@@ -244,11 +239,12 @@ func (bin Binary) build(ctx core.Context) {
 	alwaysLinkLibs := []core.Path{}
 	otherLibs := []core.Path{}
 	for _, dep := range deps {
-		ins = append(ins, dep.Out)
-		if dep.AlwaysLink {
-			alwaysLinkLibs = append(alwaysLinkLibs, dep.Out)
+		depBuildOut := dep.GetBuildOut()
+		ins = append(ins, depBuildOut)
+		if dep.IsAlwaysLink() {
+			alwaysLinkLibs = append(alwaysLinkLibs, depBuildOut)
 		} else {
-			otherLibs = append(otherLibs, dep.Out)
+			otherLibs = append(otherLibs, depBuildOut)
 		}
 	}
 

--- a/RULES/cc/toolchain.go
+++ b/RULES/cc/toolchain.go
@@ -45,18 +45,6 @@ func ToolchainFreestanding(toolchain Toolchain) bool {
 	return false
 }
 
-// ToolchainAccepts reports whether the parent toolchain accepts
-// libraries built with the child toolchain.
-func ToolchainAccepts(parent, child Toolchain) bool {
-	if parent.Name() == child.Name() {
-		return true
-	}
-	if tca, ok := parent.(interface{ Accepts(tc Toolchain) bool }); ok {
-		return tca.Accepts(child)
-	}
-	return false
-}
-
 // Toolchain represents a C++ toolchain.
 type GccToolchain struct {
 	Ar      core.GlobalPath
@@ -77,22 +65,6 @@ type GccToolchain struct {
 	ToolchainName string
 	ArchName      string
 	TargetName    string
-
-	// A list of toolchain names that libraries can be built with instead
-	// of our toolchain. (A toolchain is always compatible with
-	// itself -- there's no need to include oneself.)
-	// For example, a testing toolchain should be able to accept low-level libraries
-	// built with a non-test toolchain.
-	CompatibleWith []string
-}
-
-func (gcc GccToolchain) Accepts(tc Toolchain) bool {
-	for _, cw := range gcc.CompatibleWith {
-		if cw == tc.Name() {
-			return true
-		}
-	}
-	return false
 }
 
 func (gcc GccToolchain) Architecture() Architecture {


### PR DESCRIPTION
In order to simplify the dbt-rules, this PR makes cc.Library support multiple toolchains by default.

`Dep` interface is expanded such that it's fully isolated from `Library` struct. This will allow us to decouple `Blobs` and `Objs` from the `Library`, by making `ObjectFile` and `BlobObject` implement the `Dep` interface. The con is that this will introduce some boilerplate code.
 
I also thought about making `Dep.GetDirectDeps()` return toolchain-specific dependecies because it's not intuitive that `Dep` with toolchain A might return dependecies with other toolchains than A. But this would result in +- same code in every struct implementing `Dep` so I'd stick with `collectDepsWithToolchain()`, unless there's a simple solution I'm not seeing.

What I don't like is that `Library.Out` and `Library.GetBuildOut()` (toolchain-aware `Library.Out`) can be easily mistaken. One fix would be to let users call a constructor (like `makeLibrary()`) and put their "default output path" into a well-named variable like "defaultOut". The other option is to rename `Library.Out` to `Library.DefaultOut`, but it's not intuitive and verbose for the user.

@paulhankin I also removed the support for specifying toolchain-compatibility. I didn't see it used anywhere, but let me know if you have future use-case in mind and I'll add it back.

P.S: The PR fixes a subtle bug when `Library` has an explicit toolchain A specified, different from the default toolchain B, and it's being built with both toolchains A and B. In this case, both of them would be placed into the default user-specified destination.



 