### PR TITLE
Remove erroneous escape character in OOC constraints template

### DIFF
--- a/hdl/XilinxOutOfContextConstraints.tmpl
+++ b/hdl/XilinxOutOfContextConstraints.tmpl
@@ -1,11 +1,11 @@
 # Set clock period and create clock
 set CLOCK_PERIOD {{ .ClockPeriod }}
-create_clock -name {{ .ClockSignal }} -period \$CLOCK_PERIOD [get_ports {{ .ClockSignal }}]
+create_clock -name {{ .ClockSignal }} -period $CLOCK_PERIOD [get_ports {{ .ClockSignal }}]
 set_property HD.CLK_SRC BUFGCTRL_X0Y16 [get_ports {{ .ClockSignal }}]
 
 # Set input and output delays to this module to 40% of clock period.
-set IO_DELAY [expr 0.4 * \$CLOCK_PERIOD]
+set IO_DELAY [expr 0.4 * $CLOCK_PERIOD]
 
 # set_max_delay constrains the maximum delay *of the path*, not the assumed delay of the signal at input/outputs.
-set_max_delay -from [get_ports -filter { NAME =~ "*" && DIRECTION == "IN" && NAME != {{ .ClockSignal }} }] [ expr \$CLOCK_PERIOD - \$IO_DELAY ]
-set_max_delay -to [get_ports -filter { NAME =~ "*" && DIRECTION == "OUT" } ] [ expr \$CLOCK_PERIOD - \$IO_DELAY ]
+set_max_delay -from [get_ports -filter { NAME =~ "*" && DIRECTION == "IN" && NAME != {{ .ClockSignal }} }] [ expr $CLOCK_PERIOD - $IO_DELAY ]
+set_max_delay -to [get_ports -filter { NAME =~ "*" && DIRECTION == "OUT" } ] [ expr $CLOCK_PERIOD - $IO_DELAY ]


### PR DESCRIPTION
Erroneous escape character in template file resulted in XDC parsing
error. Constraints have been ignored.