### PR TITLE
Improved HDL simulation flow for Questa

### DIFF
--- a/RULES/hdl/hdl.go
+++ b/RULES/hdl/hdl.go
@@ -25,6 +25,7 @@ type Ip interface {
 }
 
 type Library struct {
+	Lib       string
 	Srcs      []core.Path
 	DataFiles []core.Path
 	IpDeps    []Ip

--- a/RULES/hdl/hdl.go
+++ b/RULES/hdl/hdl.go
@@ -20,8 +20,8 @@ var PartName = core.StringFlag{
 
 type Ip interface {
 	Sources() []core.Path
-	Data() []core.Path
-	Ips() []Ip
+	Data()    []core.Path
+	Ips()     []Ip
 }
 
 type Library struct {

--- a/RULES/hdl/hdl.go
+++ b/RULES/hdl/hdl.go
@@ -20,8 +20,8 @@ var PartName = core.StringFlag{
 
 type Ip interface {
 	Sources() []core.Path
-	Data()    []core.Path
-	Ips()     []Ip
+	Data() []core.Path
+	Ips() []Ip
 }
 
 type Library struct {

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -26,6 +26,14 @@ var VcomFlags = core.StringFlag{
 	},
 }.Register()
 
+// VsimFlags enables the user to specify additional flags for the 'vsim' command.
+var VsimFlags = core.StringFlag{
+	Name: "questa-vsim-flags",
+	DefaultFn: func() string {
+		return ""
+	},
+}.Register()
+
 // Access enables the user to control the accessibility in the compiled design for
 // debugging purposes.
 var Access = core.StringFlag{
@@ -451,7 +459,8 @@ func SimulateQuesta(rule Simulation, args []string, gui bool) string {
 		cmd_postamble = fmt.Sprintf("|| { cat %s; exit 1; }", log_file.String())
 	}
 
-	vsim_flags = vsim_flags + mode_flag + seed_flag + coverage_flag + verbosity_flag + plusargs_flag
+	vsim_flags = vsim_flags + mode_flag + seed_flag + coverage_flag + 
+							 verbosity_flag + plusargs_flag + VsimFlags.Value()
 
 	for _, do_flag := range do_flags {
 		vsim_flags = vsim_flags + " -do " + do_flag

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -239,6 +239,10 @@ func optimize(ctx core.Context, rule Simulation, deps []core.Path) {
 			}
 		}
 
+		if rule.TestCaseGenerator != nil {
+			deps = append(deps, rule.TestCaseGenerator)
+		}
+
 		// Add the rule to run 'vopt'.
 		ctx.AddBuildStep(core.BuildStep{
 			Out:   log_file,
@@ -349,7 +353,7 @@ func questaCmd(rule Simulation, args []string, gui bool, testcase string, params
 	log_file := rule.Path().WithSuffix("/" + log_file_suffix)
 
 	// Default flag values
-	vsim_flags := " -onfinish stop -l " + log_file.String()
+	vsim_flags := " -onfinish final -l " + log_file.String()
 	seed_flag := " -sv_seed random"
 	verbosity_flag := " +verbosity=DVM_VERB_NONE"
 	mode_flag := " -batch -quiet"

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -1,487 +1,556 @@
 package hdl
 
 import (
-	"fmt"
-	"path"
-	"strings"
-	"log"
-	"os"
+  "fmt"
+  "path"
+  "strings"
+  "log"
+  "os"
 
-	"dbt-rules/RULES/core"
+  "dbt-rules/RULES/core"
 )
 
 // VlogFlags enables the user to specify additional flags for the 'vlog' command.
 var VlogFlags = core.StringFlag{
-	Name: "questa-vlog-flags",
-	DefaultFn: func() string {
-		return ""
-	},
+  Name: "questa-vlog-flags",
+  DefaultFn: func() string {
+    return ""
+  },
 }.Register()
 
 // VcomFlags enables the user to specify additional flags for the 'vcom' command.
 var VcomFlags = core.StringFlag{
-	Name: "questa-vcom-flags",
-	DefaultFn: func() string {
-		return ""
-	},
+  Name: "questa-vcom-flags",
+  DefaultFn: func() string {
+    return ""
+  },
 }.Register()
 
 // VsimFlags enables the user to specify additional flags for the 'vsim' command.
 var VsimFlags = core.StringFlag{
-	Name: "questa-vsim-flags",
-	DefaultFn: func() string {
-		return ""
-	},
+  Name: "questa-vsim-flags",
+  DefaultFn: func() string {
+    return ""
+  },
 }.Register()
 
 // Access enables the user to control the accessibility in the compiled design for
 // debugging purposes.
 var Access = core.StringFlag{
-	Name: "questa-access",
-	DefaultFn: func() string {
-		return "rna"
-	},
+  Name: "questa-access",
+  DefaultFn: func() string {
+    return "rna"
+  },
 }.Register()
 
 // Coverage enables the user to run the simulation with code coverage.
 var Coverage = core.BoolFlag{
-	Name: "questa-coverage",
-	DefaultFn: func() bool {
-		return false
-	},
+  Name: "questa-coverage",
+  DefaultFn: func() bool {
+    return false
+  },
 }.Register()
 
 // Lib returns the standard Questa library name defined for this rule.
 func (rule Simulation) Lib() string {
-	return rule.Name + "Lib"
+  return rule.Name + "Lib"
 }
 
 // Target returns the optimization target name defined for this rule.
 func (rule Simulation) Target() string {
-	if Coverage.Value() {
-		return rule.Name + "Cov"
-	} else {
-		return rule.Name
-	}
+  if Coverage.Value() {
+    return rule.Name + "Cov"
+  } else {
+    return rule.Name
+  }
 }
 
 // Path returns the default root path for log files defined for this rule.
 func (rule Simulation) Path() core.Path {
-	return core.BuildPath("/" + rule.Name)
+  return core.BuildPath("/" + rule.Name)
 }
 
 // Instance returns the instance name of the rule based on the Top and the DUT
 // fields.
 func (rule Simulation) Instance() string {
-	// Defaults
-	top := "board"
-	dut := "u_dut"
+  // Defaults
+  top := "board"
+  dut := "u_dut"
 
-	// Pick top from rule
-	if rule.Top != "" {
-		top = rule.Top
-	} 
+  // Pick top from rule
+  if rule.Top != "" {
+    top = rule.Top
+  } 
 
-	// Pick DUT from rule
-	if rule.Dut != "" {
-		dut = rule.Dut
-	} 
+  // Pick DUT from rule
+  if rule.Dut != "" {
+    dut = rule.Dut
+  } 
 
-	return "/" + top + "/" + dut
+  return "/" + top + "/" + dut
 }
 
 // rules holds a map of all defined rules to prevent defining the same rule
 // multiple times.
 var rules = make(map[string]bool)
 
-// common_flags holds common flags used for the 'vlog', 'vcom', 'vopt' and 'vsim' commands.
+// common_flags holds common flags used for the 'vlog', 'vcom', and 'vopt' commands.
 const common_flags = "-nologo -quiet"
 
 // CompileSrcs compiles a list of sources using the specified context ctx, rule,
 // dependencies and include paths. It returns the resulting dependencies and include paths
 // that result from compiling the source files.
 func CompileSrcs(ctx core.Context, rule Simulation, 
-	               deps []core.Path, incs []core.Path, srcs []core.Path) ([]core.Path, []core.Path) {
-	for _, src := range srcs {
-		// We handle header files separately from other source files
-		if IsHeader(src.String()) {
-			incs = append(incs, src)
-		} else if IsRtl(src.String()) {
-			// log will point to the log file to be generated when compiling the code
-			log := rule.Path().WithSuffix("/" + src.Relative() + ".log")
+                 deps []core.Path, incs []core.Path, srcs []core.Path) ([]core.Path, []core.Path) {
+  for _, src := range srcs {
+    // We handle header files separately from other source files
+    if IsHeader(src.String()) {
+      incs = append(incs, src)
+    } else if IsRtl(src.String()) {
+      // log will point to the log file to be generated when compiling the code
+      log := rule.Path().WithSuffix("/" + src.Relative() + ".log")
 
-			// If we already have a rule for this file, skip it.
-			if rules[log.String()] {
-				continue
-			}
+      // If we already have a rule for this file, skip it.
+      if rules[log.String()] {
+        continue
+      }
 
-			// Holds common flags for both 'vlog' and 'vcom' commands
-			cmd := fmt.Sprintf("%s +acc=%s -work %s -l %s", common_flags, Access.Value(), rule.Lib(), log.String())
-			
-			// tool will point to the tool to execute (also used for logging below)
-			var tool string
-			if IsVerilog(src.String()) {
-				tool = "vlog"
-				cmd = cmd + " " + VlogFlags.Value()
-				cmd = cmd + " -suppress 2583 -svinputport=net"
-				cmd = cmd + fmt.Sprintf(" +incdir+%s", core.SourcePath("").String())
-				for _, inc := range incs {
-					cmd = cmd + fmt.Sprintf(" +incdir+%s", path.Dir(inc.Absolute()))
-				}
-			} else if IsVhdl(src.String()) {
-				tool = "vcom"
-			}
-			
-			// Remove the log file if the command fails to ensure we can recompile it
-			cmd = tool + " " + cmd + " " + src.String() + " || rm " + log.String()
-			
-			// Add the compilation command as a build step with the log file as the
-			// generated output
-			ctx.AddBuildStep(core.BuildStep{
-				Out:   log,
-				Ins:   append(deps, src),
-				Cmd:   cmd,
-				Descr: fmt.Sprintf("%s: %s", tool, src.Relative()),
-			})
-			
-			// Add the log file to the dependencies of the next files
-			deps = append(deps, log)
+      // Holds common flags for both 'vlog' and 'vcom' commands
+      cmd := fmt.Sprintf("%s +acc=%s -work %s -l %s", common_flags, Access.Value(), rule.Lib(), log.String())
+      
+      // tool will point to the tool to execute (also used for logging below)
+      var tool string
+      if IsVerilog(src.String()) {
+        tool = "vlog"
+        cmd = cmd + " " + VlogFlags.Value()
+        cmd = cmd + " -suppress 2583 -svinputport=net"
+        cmd = cmd + fmt.Sprintf(" +incdir+%s", core.SourcePath("").String())
+        for _, inc := range incs {
+          cmd = cmd + fmt.Sprintf(" +incdir+%s", path.Dir(inc.Absolute()))
+        }
+      } else if IsVhdl(src.String()) {
+        tool = "vcom"
+      }
+      
+      // Remove the log file if the command fails to ensure we can recompile it
+      cmd = tool + " " + cmd + " " + src.String() + " || rm " + log.String()
+      
+      // Add the compilation command as a build step with the log file as the
+      // generated output
+      ctx.AddBuildStep(core.BuildStep{
+        Out:   log,
+        Ins:   append(deps, src),
+        Cmd:   cmd,
+        Descr: fmt.Sprintf("%s: %s", tool, src.Relative()),
+      })
+      
+      // Add the log file to the dependencies of the next files
+      deps = append(deps, log)
 
-			// Note down the created rule
-			rules[log.String()] = true
-		}	
-	}
+      // Note down the created rule
+      rules[log.String()] = true
+    }	
+  }
 
-	return deps, incs
+  return deps, incs
 }
 
 // CompileIp compiles the IP dependencies and the source files and an IP.
 func CompileIp(ctx core.Context, rule Simulation, ip Ip, 
-	             deps []core.Path, incs []core.Path) ([]core.Path, []core.Path) {
-	for _, sub_ip := range ip.Ips() {
-		deps, incs = CompileIp(ctx, rule, sub_ip, deps, incs)
-	}
-	deps, incs = CompileSrcs(ctx, rule, deps, incs, ip.Sources())
+               deps []core.Path, incs []core.Path) ([]core.Path, []core.Path) {
+  for _, sub_ip := range ip.Ips() {
+    deps, incs = CompileIp(ctx, rule, sub_ip, deps, incs)
+  }
+  deps, incs = CompileSrcs(ctx, rule, deps, incs, ip.Sources())
 
-	return deps, incs
+  return deps, incs
 }
 
 // Compile compiles the IP dependencies and source files of a simulation rule.
 func Compile(ctx core.Context, rule Simulation) []core.Path {
-	incs := []core.Path{}
-	deps := []core.Path{}
+  incs := []core.Path{}
+  deps := []core.Path{}
 
-	for _, ip := range rule.Ips {
-		deps, incs = CompileIp(ctx, rule, ip, deps, incs)
-	}
-	CompileSrcs(ctx, rule, deps, incs, rule.Srcs)
+  for _, ip := range rule.Ips {
+    deps, incs = CompileIp(ctx, rule, ip, deps, incs)
+  }
+  CompileSrcs(ctx, rule, deps, incs, rule.Srcs)
 
-	return deps
+  return deps
 }
 
 // Optimize creates and optimized version of the design optionally including
 // coverage recording functionality. The optimized design unit can then conveniently
 // be simulated using 'vsim'.
 func Optimize(ctx core.Context, rule Simulation, deps []core.Path) {
-	top := "board"
-	if rule.Top != "" {
-		top = rule.Top
-	}
-	
-	cover_flag := ""
-	log_file_suffix := "/vopt.log"
-	if Coverage.Value() {
-		cover_flag = "+cover"
-		log_file_suffix = "/vopt_cover.log"
-	}
+  top := "board"
+  if rule.Top != "" {
+    top = rule.Top
+  }
+  
+  cover_flag := ""
+  log_file_suffix := "vopt.log"
+  if Coverage.Value() {
+    cover_flag = "+cover"
+    log_file_suffix = "vopt_cover.log"
+  }
 
-	log_files := []core.Path{}
-	targets := []string{}
-	params := []string{}
-	if rule.Params != nil {
-		for key, _ := range rule.Params {
-			log_files = append(log_files, rule.Path().WithSuffix(key))
-			targets = append(targets, rule.Target() + key)
-			params = append(params, key)
-		}
-	} else {
-		log_files = append(log_files, rule.Path())
-		targets = append(targets, rule.Target())
-		params = append(params, "")
-	}
+  log_files := []core.OutPath{}
+  targets := []string{}
+  params := []string{}
+  if rule.Params != nil {
+    for key, _ := range rule.Params {
+      log_files = append(log_files, rule.Path().WithSuffix("/" + key + "_" + log_file_suffix))
+      targets = append(targets, rule.Target() + key)
+      params = append(params, key)
+    }
+  } else {
+    log_files = append(log_files, rule.Path().WithSuffix("/" + log_file_suffix))
+    targets = append(targets, rule.Target())
+    params = append(params, "")
+  }
 
-	for i := range log_files {
-		log_file := log_files[i].WithSuffix(log_file_suffix)
-		target := targets[i]
-		param_set := params[i]
+  for i := range log_files {
+    log_file := log_files[i]
+    target := targets[i]
+    param_set := params[i]
 
-		// Skip if we already have a rule
-		if rules[log_file.String()] {
-			return
-		}
+    // Skip if we already have a rule
+    if rules[log_file.String()] {
+      return
+    }
 
-		cmd := fmt.Sprintf("vopt %s %s +acc=%s -l %s -work %s %s -o %s", 
-											common_flags, cover_flag, Access.Value(),
-											log_file.String(), rule.Lib(), top, target)
+    cmd := fmt.Sprintf("vopt %s %s +acc=%s -l %s -work %s %s -o %s", 
+                      common_flags, cover_flag, Access.Value(),
+                      log_file.String(), rule.Lib(), top, target)
 
-		// Set up parameters
-		if param_set != "" {
-			// Check that the parameters exist
-			if params, ok := rule.Params[param_set]; ok {
-				// Add parameters for all generics
-				for param, value := range params {
-					cmd = fmt.Sprintf("%s -G %s=%s", cmd, param, value)
-				}
-			} else {
-				log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!", 
-				          params, rule.Name))
-			}
-		}
-		
-		// Add the rule to run 'vopt'.
-		ctx.AddBuildStep(core.BuildStep{
-			Out:   log_file,
-			Ins:   deps,
-			Cmd:   cmd,
-			Descr: fmt.Sprintf("vopt: %s %s", rule.Lib() + "." + top, target),
-		})
+    // Set up parameters
+    if param_set != "" {
+      // Check that the parameters exist
+      if params, ok := rule.Params[param_set]; ok {
+        // Add parameters for all generics
+        for param, value := range params {
+          cmd = fmt.Sprintf("%s -G %s=%s", cmd, param, value)
+        }
+      } else {
+        log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!", 
+                  params, rule.Name))
+      }
+    }
+    
+    // Add the rule to run 'vopt'.
+    ctx.AddBuildStep(core.BuildStep{
+      Out:   log_file,
+      Ins:   deps,
+      Cmd:   cmd,
+      Descr: fmt.Sprintf("vopt: %s %s", rule.Lib() + "." + top, target),
+    })
 
-		// Note that we created this rule
-		rules[log_file.String()] = true
-	}
+    // Note that we created this rule
+    rules[log_file.String()] = true
+  }
 }
 
 // BuildQuesta will compile and optimize the source and IPs associated with the given
 // rule.
 func BuildQuesta(ctx core.Context, rule Simulation) {
-	// Compile the code
-	deps := Compile(ctx, rule)
+  // Compile the code
+  deps := Compile(ctx, rule)
 
-	// Optimize the code
-	Optimize(ctx, rule, deps)
+  // Optimize the code
+  Optimize(ctx, rule, deps)
 }
 
 // VerbosityLevelToFlag takes a verbosity level of none, low, medium or high and
 // converts it to the corresponding DVM_ level.
 func VerbosityLevelToFlag(level string) (string, bool) {
-	var verbosity_flag string
-	var print_output bool
-	switch level {
-		case "none":   
-			verbosity_flag = " +verbosity=DVM_VERB_NONE"
-			print_output = false
-		case "low":    
-			verbosity_flag = " +verbosity=DVM_VERB_LOW"
-			print_output = true
-		case "medium":
-			verbosity_flag = " +verbosity=DVM_VERB_MED"
-			print_output = true
-		case "high":
-			verbosity_flag = " +verbosity=DVM_VERB_HIGH"
-			print_output = true
-		default:
-			log.Fatal(fmt.Sprintf("invalid verbosity flag '%s', only 'low', 'medium'," + 
-			                      " 'high' or 'none' allowed!", level))
-		}
+  var verbosity_flag string
+  var print_output bool
+  switch level {
+    case "none":   
+      verbosity_flag = " +verbosity=DVM_VERB_NONE"
+      print_output = false
+    case "low":    
+      verbosity_flag = " +verbosity=DVM_VERB_LOW"
+      print_output = true
+    case "medium":
+      verbosity_flag = " +verbosity=DVM_VERB_MED"
+      print_output = true
+    case "high":
+      verbosity_flag = " +verbosity=DVM_VERB_HIGH"
+      print_output = true
+    default:
+      log.Fatal(fmt.Sprintf("invalid verbosity flag '%s', only 'low', 'medium'," + 
+                            " 'high' or 'none' allowed!", level))
+    }
 
-		return verbosity_flag, print_output
+    return verbosity_flag, print_output
 }
 
 // Preamble creates a preamble for the simulation command for the purpose of generating
 // a testcase.
 func Preamble(rule Simulation, testcase string) (string, string) {
-	preamble := ""
+  preamble := ""
 
-	// Create a testcase generation command if necessary
-	if rule.TestCaseGenerator != nil {
-		// No testcase specified, use default
-		if testcase == "" {
-			// If directory of testcases available, pick the first one
-			if rule.TestCasesDir != nil {
-				if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
-					if len(items) == 0 {
-						log.Fatal(fmt.Sprintf("TestCasesDir directory '%s' empty!", rule.TestCasesDir.String()))
-					}
+  // Create a testcase generation command if necessary
+  if rule.TestCaseGenerator != nil {
+    // No testcase specified, use default
+    if testcase == "" {
+      // If directory of testcases available, pick the first one
+      if rule.TestCasesDir != nil {
+        if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
+          if len(items) == 0 {
+            log.Fatal(fmt.Sprintf("TestCasesDir directory '%s' empty!", rule.TestCasesDir.String()))
+          }
 
-					// Create path to testcase
-					testcase = rule.TestCasesDir.Absolute() + "/" + items[0].Name()
-				}
-			}
-		} else if testcase != "" && rule.TestCasesDir != nil {
-			// Create path to testcase
-			testcase = rule.TestCasesDir.Absolute() + "/" + testcase
-		}
+          // Create path to testcase
+          testcase = rule.TestCasesDir.Absolute() + "/" + items[0].Name()
+        }
+      }
+    } else if testcase != "" && rule.TestCasesDir != nil {
+      // Create path to testcase
+      testcase = rule.TestCasesDir.Absolute() + "/" + testcase
+    }
 
-		if testcase == "" {
-			// Create the preamble for testcase generator without any argument
-			preamble = fmt.Sprintf("{ %s . ; }", rule.TestCaseGenerator.String())
-			testcase = "default"
-		} else {
-			// Create the preamble for testcase generator with arguments
-			preamble = fmt.Sprintf("{ %s %s . ; }", rule.TestCaseGenerator.String(), testcase)
-		}
+    if testcase == "" {
+      // Create the preamble for testcase generator without any argument
+      preamble = fmt.Sprintf("{ %s . ; }", rule.TestCaseGenerator.String())
+      testcase = "default"
+    } else {
+      // Create the preamble for testcase generator with arguments
+      preamble = fmt.Sprintf("{ %s %s . ; }", rule.TestCaseGenerator.String(), testcase)
+    }
 
-		// Add information to command
-		preamble = fmt.Sprintf("{ echo Testcase %s; } && ", testcase) + preamble
+    // Add information to command
+    preamble = fmt.Sprintf("{ echo Generating %s; } && ", testcase) + preamble
 
-		// Trim testcase for use in coverage databaes
-		testcase = strings.TrimSuffix(path.Base(testcase), path.Ext(testcase))
-	}
+    // Trim testcase for use in coverage databaes
+    testcase = strings.TrimSuffix(path.Base(testcase), path.Ext(testcase))
+  }
 
-	return preamble, testcase
+  return preamble, testcase
 }
 
-// Simulate will start 'vsim' on the compiled design with flags set in accordance
-// with what is specified on the command line.
+// QuestaCmd will create a command for starting 'vsim' on the compiled and optimized design with flags
+// set in accordance with what is specified on the command line.
+func QuestaCmd(rule Simulation, args []string, gui bool, testcase string, params string) string {
+  // Prefix the vsim command with this
+  cmd_preamble := ""
+  
+  // Default log file
+	log_file_suffix := "vsim.log"
+	if testcase != "" {
+		log_file_suffix = testcase + "_" + log_file_suffix
+	}
+	if params != "" {
+		log_file_suffix = params + "_" + log_file_suffix
+	}
+  log_file := rule.Path().WithSuffix("/" + log_file_suffix)
+
+  // Default flag values
+  vsim_flags     := " -onfinish stop -l " + log_file.String()
+  seed_flag      := " -sv_seed random"
+  verbosity_flag := " +verbosity=DVM_VERB_NONE"
+  mode_flag      := " -batch -quiet"
+  plusargs_flag  := ""
+
+  // Enable coverage in simulator
+  coverage_flag := ""
+  if Coverage.Value() {
+    coverage_flag = " -coverage"
+  }
+
+  // Determine the names of the coverage databases
+  coverage_db := rule.Name
+
+  // Collect do-files here
+  var do_flags []string
+
+  // Turn off output unless verbosity is activated
+  print_output := false
+
+  // Parse additional arguments
+  for _, arg := range args {
+    if strings.HasPrefix(arg, "-seed=") {
+      // Define simulator seed
+      var seed int64
+      if _, err := fmt.Sscanf(arg, "-seed=%d", &seed); err == nil {
+        seed_flag = fmt.Sprintf(" -sv_seed %d", seed)
+      } else {
+        log.Fatal("-seed expects an integer argument!")
+      }
+    } else if strings.HasPrefix(arg, "-verbosity=") {
+      // Define verbosity level
+      var level string
+      if _, err := fmt.Sscanf(arg, "-verbosity=%s", &level); err == nil {
+        verbosity_flag, print_output = VerbosityLevelToFlag(level)
+      } else {
+        log.Fatal("-verbosity expects an argument of 'low', 'medium', 'high' or 'none'!")
+      }
+    }	else if strings.HasPrefix(arg, "+") {
+      // All '+' arguments go directly to the simulator
+      plusargs_flag = plusargs_flag + " " + arg
+    } 
+  }
+
+  // Create optional command preamble
+  cmd_preamble, testcase = Preamble(rule, testcase)
+
+	cmd_echo := ""
+  if rule.Params != nil && params != "" {
+    // Update coverage database name
+    if testcase != "" {
+      coverage_db = coverage_db + "_" + params + "_" + testcase
+      testcase = params + "_" + testcase
+			cmd_echo = "Testcase " + params + "/" + testcase + ":"
+    } else {
+      coverage_db = coverage_db + "_" + params
+      testcase = params
+			cmd_echo = "Testcase " + params + ":"
+    }
+  } else {
+    // Update coverage database name
+    if testcase != "" {
+      coverage_db = coverage_db + "_" + testcase
+			cmd_echo = "Testcase " + testcase + ":"
+    } else {
+      testcase = "default"
+    }
+  }
+
+  cmd_postamble := "" 
+  if gui {
+    mode_flag = " -gui"
+    if rule.WaveformInit != nil {
+      do_flags = append(do_flags, rule.WaveformInit.String())
+    }
+  } else {
+    if !print_output {
+      mode_flag = mode_flag + " -nostdout"
+    }
+    do_flags = append(do_flags, "\"run -all\"")
+    if Coverage.Value() {
+      do_flags = append(do_flags, 
+        fmt.Sprintf("\"coverage report -html -output %s_covhtml -details -assert" + 
+                    " -directive -cvg -code bcefst -threshL 50 -threshH 90\"", coverage_db))
+      do_flags = append(do_flags, fmt.Sprintf("\"coverage save -assert" +
+                                              " -directive -cvg -codeAll -testname %s" + 
+                                              " -instance %s %s.ucdb\"", 
+                                              testcase, rule.Instance(), coverage_db))
+      do_flags = append(do_flags, fmt.Sprintf("\"vcover merge -out %s.ucdb {*}[glob %s*.ucdb]\"", rule.Name, rule.Name))
+      do_flags = append(do_flags, fmt.Sprintf("\"file delete {*}[glob -nocomplain %s_*.ucdb]\"", rule.Name))
+    }
+    do_flags = append(do_flags, "\"quit -code [coverage attribute -name TESTSTATUS -concise]\"")
+		cmd_newline := ":"
+		if cmd_echo != "" {
+			cmd_newline = "echo"
+		}
+    cmd_postamble = fmt.Sprintf("|| { %s; cat %s; exit 1; }", cmd_newline, log_file.String())
+  }
+
+  vsim_flags = vsim_flags + mode_flag + seed_flag + coverage_flag + 
+               verbosity_flag + plusargs_flag + VsimFlags.Value()
+
+  for _, do_flag := range do_flags {
+    vsim_flags = vsim_flags + " -do " + do_flag
+  }
+
+  cmd := fmt.Sprintf("{ echo -n %s && vsim %s -work %s %s && echo OK; }", cmd_echo, vsim_flags, rule.Lib(), rule.Target() + params)
+  if cmd_preamble == "" {
+    cmd = cmd + " " + cmd_postamble
+  } else {
+    cmd = "{ { " + cmd_preamble + " } && " + cmd + " } " + cmd_postamble
+  }
+
+	// Wrap command in another layer of {} to enable chaining
+	cmd = "{ " + cmd + " }"
+
+  return cmd
+}
+
+// SimulateQuesta will create a command to start 'vsim' on the compiled design 
+// with flags set in accordance with what is specified on the command line. It will
+// optionally build a chain of commands in case the rule has parameters, but
+// no parameters are specified on the command line
 func SimulateQuesta(rule Simulation, args []string, gui bool) string {
-	// Prefix the vsim command with this
-	cmd_preamble := ""
-	
-	// Default log file
-	log_file := rule.Path().WithSuffix("/vsim.log")
+  // Optional testcase goes here
+  testcases := []string{}
 
-	// Default flag values
-	vsim_flags     := " -onfinish stop -l " + log_file.String()
-	seed_flag      := " -sv_seed random"
-	verbosity_flag := " +verbosity=DVM_VERB_NONE"
-	mode_flag      := " -batch -quiet"
-	plusargs_flag  := ""
+  // Optional parameter set goes here
+  params := []string{}
 
-	// Enable coverage in simulator
-	coverage_flag := ""
-	if Coverage.Value() {
-		coverage_flag = " -coverage"
+  // Parse additional arguments
+  for _, arg := range args {
+    if strings.HasPrefix(arg, "-testcase=")  && rule.TestCaseGenerator != nil {
+			var testcase string
+      if _, err := fmt.Sscanf(arg, "-testcase=%s", &testcase); err != nil {
+        log.Fatal(fmt.Sprintf("-testcase expects a string argument!"))
+      }
+			testcases = append(testcases, testcase)
+    }	else if strings.HasPrefix(arg, "-params=")  && rule.Params != nil {
+			var param string
+      if _, err := fmt.Sscanf(arg, "-params=%s", &param); err != nil {
+        log.Fatal(fmt.Sprintf("-params expects a string argument!"))
+      } else {
+        if _, ok := rule.Params[param]; !ok {
+          log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!", param, rule.Name))
+        }
+				params = append(params, param)
+      }
+    }
+  }
+
+	// If no parameters have been specified, simulate them all
+	if rule.Params != nil && len(params) == 0 {
+		for key := range rule.Params {
+			params = append(params, key)
+		}
+	} else if len(params) == 0 {
+		params = append(params, "")
 	}
 
-	// Determine the names of the coverage databases
-	coverage_db := rule.Name
-
-	// Collect do-files here
-	var do_flags []string
-
-	// Turn off output unless verbosity is activated
-	print_output := false
-
-	// Optional testcase goes here
-	testcase := ""
-
-	// Optional parameter set goes here
-	params := ""
-
-	// Parse additional arguments
-	for _, arg := range args {
-		if strings.HasPrefix(arg, "-seed=") {
-			// Define simulator seed
-			var seed int64
-			if _, err := fmt.Sscanf(arg, "-seed=%d", &seed); err == nil {
-				seed_flag = fmt.Sprintf(" -sv_seed %d", seed)
-			} else {
-				log.Fatal("-seed expects an integer argument!")
-			}
-		} else if strings.HasPrefix(arg, "-verbosity=") {
-			// Define verbosity level
-			var level string
-			if _, err := fmt.Sscanf(arg, "-verbosity=%s", &level); err == nil {
-				verbosity_flag, print_output = VerbosityLevelToFlag(level)
-			} else {
-				log.Fatal("-verbosity expects an argument of 'low', 'medium', 'high' or 'none'!")
-			}
-		}	else if strings.HasPrefix(arg, "-testcase=")  && rule.TestCaseGenerator != nil {
-			if _, err := fmt.Sscanf(arg, "-testcase=%s", &testcase); err != nil {
-				log.Fatal(fmt.Sprintf("-testcase expects a string argument!"))
-			}
-		}	else if strings.HasPrefix(arg, "-params=")  && rule.Params != nil {
-			if _, err := fmt.Sscanf(arg, "-params=%s", &params); err != nil {
-				log.Fatal(fmt.Sprintf("-params expects a string argument!"))
-			} else {
-				if _, ok := rule.Params[params]; !ok {
-					log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!", params, rule.Name))
-				}
-			}
-		}	else if strings.HasPrefix(arg, "+") {
-			// All '+' arguments go directly to the simulator
-			plusargs_flag = plusargs_flag + " " + arg
-		} 
+	// If no testcase has been specified, simulate them all
+	if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil && len(testcases) == 0 {    
+    // Loop through all defined testcases in directory
+    if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
+      for _, item := range items {
+        testcases = append(testcases, item.Name())
+      }
+    } else {
+      log.Fatal(err)
+    }
+  } else if len(testcases) == 0 {
+		testcases = append(testcases, "")
 	}
 
-	// Create optional command preamble
-	cmd_preamble, testcase = Preamble(rule, testcase)
+	// Final command
+	cmd := "{ :; }"
 
-	// Update params name
-	if rule.Params != nil && params == "" {
-		// Pick first parameter set
-		for params = range rule.Params {
+	// Loop for all parameter sets
+	for i := range params {
+		// Loop for all test cases
+		for j := range testcases {
+			cmd = cmd + " && " + QuestaCmd(rule, args, gui, testcases[j], params[i])
+			// Only one testcase allowed in GUI mode
+			if gui {
+				break
+			}
+		}
+		// Only one parameter set allowed in gui mode
+		if gui {
 			break
 		}
 	}
 
-	if rule.Params != nil && params != "" {
-		// Update coverage database name
-		if testcase != "" {
-			coverage_db = coverage_db + "_" + params + "_" + testcase
-			testcase = params + "_" + testcase
-		} else {
-			coverage_db = coverage_db + "_" + params
-			testcase = params
-		}
-	} else {
-		// Update coverage database name
-		if testcase != "" {
-			coverage_db = coverage_db + "_" + testcase
-		} else {
-			testcase = "default"
-		}
-	}
-
-	cmd_postamble := "" 
-	if gui {
-		mode_flag = " -gui"
-		if rule.WaveformInit != nil {
-			do_flags = append(do_flags, rule.WaveformInit.String())
-		}
-	} else {
-		if !print_output {
-			mode_flag = mode_flag + " -nostdout"
-		}
-		do_flags = append(do_flags, "\"run -all\"")
-		if Coverage.Value() {
-			do_flags = append(do_flags, 
-				fmt.Sprintf("\"coverage report -html -output %s_covhtml -details -assert" + 
-				            " -directive -cvg -code bcefst -threshL 50 -threshH 90\"", coverage_db))
-			do_flags = append(do_flags, fmt.Sprintf("\"coverage save -assert" +
-			                                        " -directive -cvg -codeAll -testname %s" + 
-																							" -instance %s %s.ucdb\"", 
-																							testcase, rule.Instance(), coverage_db))
-			do_flags = append(do_flags, fmt.Sprintf("\"vcover merge -out %s.ucdb {*}[glob %s*.ucdb]\"", rule.Name, rule.Name))
-			do_flags = append(do_flags, fmt.Sprintf("\"file delete {*}[glob -nocomplain %s_*.ucdb]\"", rule.Name))
-		}
-		do_flags = append(do_flags, "\"quit -code [coverage attribute -name TESTSTATUS -concise]\"")
-		cmd_postamble = fmt.Sprintf("|| { cat %s; exit 1; }", log_file.String())
-	}
-
-	vsim_flags = vsim_flags + mode_flag + seed_flag + coverage_flag + 
-							 verbosity_flag + plusargs_flag + VsimFlags.Value()
-
-	for _, do_flag := range do_flags {
-		vsim_flags = vsim_flags + " -do " + do_flag
-	}
-
-	cmd := fmt.Sprintf("{ vsim %s -work %s %s; }", vsim_flags, rule.Lib(), rule.Target() + params)
-	if cmd_preamble == "" {
-		cmd = cmd + " " + cmd_postamble
-	} else {
-		cmd = "{ { " + cmd_preamble + " } && " + cmd + " } " + cmd_postamble
-	}
-
-	return cmd
+  return cmd
 }
 
 // Run will build the design and run a simulation in GUI mode.
 func RunQuesta(rule Simulation, args []string) string {
-	return SimulateQuesta(rule, args, true)
+  return SimulateQuesta(rule, args, true)
 }
 
 // Test will build the design and run a simulation in batch mode.
 func TestQuesta(rule Simulation, args []string) string {
-	return SimulateQuesta(rule, args, false)
+  return SimulateQuesta(rule, args, false)
 }

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -68,9 +68,9 @@ var CoverageHtml = core.BoolFlag{
 // Target returns the optimization target name defined for this rule.
 func (rule Simulation) Target() string {
 	if Coverage.Value() {
-		return rule.Name + "Cov"
+		return rule.Name + "_OptCov"
 	} else {
-		return rule.Name
+		return rule.Name + "_Opt"
 	}
 }
 

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -59,11 +59,6 @@ var CoverageHtml = core.BoolFlag{
   },
 }.Register()
 
-// Lib returns the standard Questa library name defined for this rule.
-func (rule Simulation) Lib() string {
-  return rule.Name + "Lib"
-}
-
 // Target returns the optimization target name defined for this rule.
 func (rule Simulation) Target() string {
   if Coverage.Value() {
@@ -71,11 +66,6 @@ func (rule Simulation) Target() string {
   } else {
     return rule.Name
   }
-}
-
-// Path returns the default root path for log files defined for this rule.
-func (rule Simulation) Path() core.Path {
-  return core.BuildPath("/" + rule.Name)
 }
 
 // Instance returns the instance name of the rule based on the Top and the DUT
@@ -182,7 +172,7 @@ func compile(ctx core.Context, rule Simulation) []core.Path {
   for _, ip := range rule.Ips {
     deps, incs = compileIp(ctx, rule, ip, deps, incs)
   }
-  compileSrcs(ctx, rule, deps, incs, rule.Srcs)
+  deps, incs = compileSrcs(ctx, rule, deps, incs, rule.Srcs)
 
   return deps
 }

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -1,91 +1,91 @@
 package hdl
 
 import (
-  "fmt"
-  "log"
-  "os"
-  "path"
-  "strings"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"strings"
 
-  "dbt-rules/RULES/core"
+	"dbt-rules/RULES/core"
 )
 
 // VlogFlags enables the user to specify additional flags for the 'vlog' command.
 var VlogFlags = core.StringFlag{
-  Name: "questa-vlog-flags",
-  DefaultFn: func() string {
-    return ""
-  },
+	Name: "questa-vlog-flags",
+	DefaultFn: func() string {
+		return ""
+	},
 }.Register()
 
 // VcomFlags enables the user to specify additional flags for the 'vcom' command.
 var VcomFlags = core.StringFlag{
-  Name: "questa-vcom-flags",
-  DefaultFn: func() string {
-    return ""
-  },
+	Name: "questa-vcom-flags",
+	DefaultFn: func() string {
+		return ""
+	},
 }.Register()
 
 // VsimFlags enables the user to specify additional flags for the 'vsim' command.
 var VsimFlags = core.StringFlag{
-  Name: "questa-vsim-flags",
-  DefaultFn: func() string {
-    return ""
-  },
+	Name: "questa-vsim-flags",
+	DefaultFn: func() string {
+		return ""
+	},
 }.Register()
 
 // Access enables the user to control the accessibility in the compiled design for
 // debugging purposes.
 var Access = core.StringFlag{
-  Name: "questa-access",
-  DefaultFn: func() string {
-    return "rna"
-  },
+	Name: "questa-access",
+	DefaultFn: func() string {
+		return "rna"
+	},
 }.Register()
 
 // Coverage enables the user to run the simulation with code coverage.
 var Coverage = core.BoolFlag{
-  Name: "questa-coverage",
-  DefaultFn: func() bool {
-    return false
-  },
+	Name: "questa-coverage",
+	DefaultFn: func() bool {
+		return false
+	},
 }.Register()
 
 // CoverageHtml enables the generation of an Html report in the output directory
 var CoverageHtml = core.BoolFlag{
-  Name: "questa-coverage-html",
-  DefaultFn: func() bool {
-    return false
-  },
+	Name: "questa-coverage-html",
+	DefaultFn: func() bool {
+		return false
+	},
 }.Register()
 
 // Target returns the optimization target name defined for this rule.
 func (rule Simulation) Target() string {
-  if Coverage.Value() {
-    return rule.Name + "Cov"
-  } else {
-    return rule.Name
-  }
+	if Coverage.Value() {
+		return rule.Name + "Cov"
+	} else {
+		return rule.Name
+	}
 }
 
 // Instance returns the instance name of the rule based on the Top and the DUT
 // fields.
 func (rule Simulation) Instance() string {
-  // Defaults
-  top := "board"
-  dut := "u_dut"
+	// Defaults
+	top := "board"
+	dut := "u_dut"
 
-  // Pick top from rule
-  if rule.Top != "" {
-    top = rule.Top
-  }
+	// Pick top from rule
+	if rule.Top != "" {
+		top = rule.Top
+	}
 
-  // Pick DUT from rule
-  if rule.Dut != "" {
-    dut = rule.Dut
-  }
+	// Pick DUT from rule
+	if rule.Dut != "" {
+		dut = rule.Dut
+	}
 
-  return "/" + top + "/" + dut
+	return "/" + top + "/" + dut
 }
 
 // rules holds a map of all defined rules to prevent defining the same rule
@@ -99,385 +99,385 @@ const common_flags = "-nologo -quiet"
 // dependencies and include paths. It returns the resulting dependencies and include paths
 // that result from compiling the source files.
 func compileSrcs(ctx core.Context, rule Simulation,
-  deps []core.Path, incs []core.Path, srcs []core.Path) ([]core.Path, []core.Path) {
-  for _, src := range srcs {
-    // We handle header files separately from other source files
-    if IsHeader(src.String()) {
-      incs = append(incs, src)
-    } else if IsRtl(src.String()) {
-      // log will point to the log file to be generated when compiling the code
-      log := rule.Path().WithSuffix("/" + src.Relative() + ".log")
+	deps []core.Path, incs []core.Path, srcs []core.Path) ([]core.Path, []core.Path) {
+	for _, src := range srcs {
+		// We handle header files separately from other source files
+		if IsHeader(src.String()) {
+			incs = append(incs, src)
+		} else if IsRtl(src.String()) {
+			// log will point to the log file to be generated when compiling the code
+			log := rule.Path().WithSuffix("/" + src.Relative() + ".log")
 
-      // If we already have a rule for this file, skip it.
-      if rules[log.String()] {
-        continue
-      }
+			// If we already have a rule for this file, skip it.
+			if rules[log.String()] {
+				continue
+			}
 
-      // Holds common flags for both 'vlog' and 'vcom' commands
-      cmd := fmt.Sprintf("%s +acc=%s -work %s -l %s", common_flags, Access.Value(), rule.Lib(), log.String())
+			// Holds common flags for both 'vlog' and 'vcom' commands
+			cmd := fmt.Sprintf("%s +acc=%s -work %s -l %s", common_flags, Access.Value(), rule.Lib(), log.String())
 
-      // tool will point to the tool to execute (also used for logging below)
-      var tool string
-      if IsVerilog(src.String()) {
-        tool = "vlog"
-        cmd = cmd + " " + VlogFlags.Value()
-        cmd = cmd + " -suppress 2583 -svinputport=net"
-        cmd = cmd + fmt.Sprintf(" +incdir+%s", core.SourcePath("").String())
-        for _, inc := range incs {
-          cmd = cmd + fmt.Sprintf(" +incdir+%s", path.Dir(inc.Absolute()))
-        }
-      } else if IsVhdl(src.String()) {
-        tool = "vcom"
-      }
+			// tool will point to the tool to execute (also used for logging below)
+			var tool string
+			if IsVerilog(src.String()) {
+				tool = "vlog"
+				cmd = cmd + " " + VlogFlags.Value()
+				cmd = cmd + " -suppress 2583 -svinputport=net"
+				cmd = cmd + fmt.Sprintf(" +incdir+%s", core.SourcePath("").String())
+				for _, inc := range incs {
+					cmd = cmd + fmt.Sprintf(" +incdir+%s", path.Dir(inc.Absolute()))
+				}
+			} else if IsVhdl(src.String()) {
+				tool = "vcom"
+			}
 
-      // Remove the log file if the command fails to ensure we can recompile it
-      cmd = tool + " " + cmd + " " + src.String() + " || rm " + log.String()
+			// Remove the log file if the command fails to ensure we can recompile it
+			cmd = tool + " " + cmd + " " + src.String() + " || rm " + log.String()
 
-      // Add the compilation command as a build step with the log file as the
-      // generated output
-      ctx.AddBuildStep(core.BuildStep{
-        Out:   log,
-        Ins:   append(deps, src),
-        Cmd:   cmd,
-        Descr: fmt.Sprintf("%s: %s", tool, src.Relative()),
-      })
+			// Add the compilation command as a build step with the log file as the
+			// generated output
+			ctx.AddBuildStep(core.BuildStep{
+				Out:   log,
+				Ins:   append(deps, src),
+				Cmd:   cmd,
+				Descr: fmt.Sprintf("%s: %s", tool, src.Relative()),
+			})
 
-      // Add the log file to the dependencies of the next files
-      deps = append(deps, log)
+			// Add the log file to the dependencies of the next files
+			deps = append(deps, log)
 
-      // Note down the created rule
-      rules[log.String()] = true
-    }
-  }
+			// Note down the created rule
+			rules[log.String()] = true
+		}
+	}
 
-  return deps, incs
+	return deps, incs
 }
 
 // compileIp compiles the IP dependencies and the source files and an IP.
 func compileIp(ctx core.Context, rule Simulation, ip Ip,
-  deps []core.Path, incs []core.Path) ([]core.Path, []core.Path) {
-  for _, sub_ip := range ip.Ips() {
-    deps, incs = compileIp(ctx, rule, sub_ip, deps, incs)
-  }
-  deps, incs = compileSrcs(ctx, rule, deps, incs, ip.Sources())
+	deps []core.Path, incs []core.Path) ([]core.Path, []core.Path) {
+	for _, sub_ip := range ip.Ips() {
+		deps, incs = compileIp(ctx, rule, sub_ip, deps, incs)
+	}
+	deps, incs = compileSrcs(ctx, rule, deps, incs, ip.Sources())
 
-  return deps, incs
+	return deps, incs
 }
 
 // compile compiles the IP dependencies and source files of a simulation rule.
 func compile(ctx core.Context, rule Simulation) []core.Path {
-  incs := []core.Path{}
-  deps := []core.Path{}
+	incs := []core.Path{}
+	deps := []core.Path{}
 
-  for _, ip := range rule.Ips {
-    deps, incs = compileIp(ctx, rule, ip, deps, incs)
-  }
-  deps, incs = compileSrcs(ctx, rule, deps, incs, rule.Srcs)
+	for _, ip := range rule.Ips {
+		deps, incs = compileIp(ctx, rule, ip, deps, incs)
+	}
+	deps, incs = compileSrcs(ctx, rule, deps, incs, rule.Srcs)
 
-  return deps
+	return deps
 }
 
 // optimize creates and optimized version of the design optionally including
 // coverage recording functionality. The optimized design unit can then conveniently
 // be simulated using 'vsim'.
 func optimize(ctx core.Context, rule Simulation, deps []core.Path) {
-  top := "board"
-  if rule.Top != "" {
-    top = rule.Top
-  }
+	top := "board"
+	if rule.Top != "" {
+		top = rule.Top
+	}
 
-  cover_flag := ""
-  log_file_suffix := "vopt.log"
-  if Coverage.Value() {
-    cover_flag = "+cover"
-    log_file_suffix = "vopt_cover.log"
-  }
+	cover_flag := ""
+	log_file_suffix := "vopt.log"
+	if Coverage.Value() {
+		cover_flag = "+cover"
+		log_file_suffix = "vopt_cover.log"
+	}
 
-  log_files := []core.OutPath{}
-  targets := []string{}
-  params := []string{}
-  if rule.Params != nil {
-    for key, _ := range rule.Params {
-      log_files = append(log_files, rule.Path().WithSuffix("/"+key+"_"+log_file_suffix))
-      targets = append(targets, rule.Target()+key)
-      params = append(params, key)
-    }
-  } else {
-    log_files = append(log_files, rule.Path().WithSuffix("/"+log_file_suffix))
-    targets = append(targets, rule.Target())
-    params = append(params, "")
-  }
+	log_files := []core.OutPath{}
+	targets := []string{}
+	params := []string{}
+	if rule.Params != nil {
+		for key, _ := range rule.Params {
+			log_files = append(log_files, rule.Path().WithSuffix("/"+key+"_"+log_file_suffix))
+			targets = append(targets, rule.Target()+key)
+			params = append(params, key)
+		}
+	} else {
+		log_files = append(log_files, rule.Path().WithSuffix("/"+log_file_suffix))
+		targets = append(targets, rule.Target())
+		params = append(params, "")
+	}
 
-  for i := range log_files {
-    log_file := log_files[i]
-    target := targets[i]
-    param_set := params[i]
+	for i := range log_files {
+		log_file := log_files[i]
+		target := targets[i]
+		param_set := params[i]
 
-    // Skip if we already have a rule
-    if rules[log_file.String()] {
-      return
-    }
+		// Skip if we already have a rule
+		if rules[log_file.String()] {
+			return
+		}
 
-    cmd := fmt.Sprintf("vopt %s %s +acc=%s -l %s -work %s %s -o %s",
-      common_flags, cover_flag, Access.Value(),
-      log_file.String(), rule.Lib(), top, target)
+		cmd := fmt.Sprintf("vopt %s %s +acc=%s -l %s -work %s %s -o %s",
+			common_flags, cover_flag, Access.Value(),
+			log_file.String(), rule.Lib(), top, target)
 
-    // Set up parameters
-    if param_set != "" {
-      // Check that the parameters exist
-      if params, ok := rule.Params[param_set]; ok {
-        // Add parameters for all generics
-        for param, value := range params {
-          cmd = fmt.Sprintf("%s -G %s=%s", cmd, param, value)
-        }
-      } else {
-        log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!",
-          params, rule.Name))
-      }
-    }
+		// Set up parameters
+		if param_set != "" {
+			// Check that the parameters exist
+			if params, ok := rule.Params[param_set]; ok {
+				// Add parameters for all generics
+				for param, value := range params {
+					cmd = fmt.Sprintf("%s -G %s=%s", cmd, param, value)
+				}
+			} else {
+				log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!",
+					params, rule.Name))
+			}
+		}
 
-    // Add the rule to run 'vopt'.
-    ctx.AddBuildStep(core.BuildStep{
-      Out:   log_file,
-      Ins:   deps,
-      Cmd:   cmd,
-      Descr: fmt.Sprintf("vopt: %s %s", rule.Lib()+"."+top, target),
-    })
+		// Add the rule to run 'vopt'.
+		ctx.AddBuildStep(core.BuildStep{
+			Out:   log_file,
+			Ins:   deps,
+			Cmd:   cmd,
+			Descr: fmt.Sprintf("vopt: %s %s", rule.Lib()+"."+top, target),
+		})
 
-    // Note that we created this rule
-    rules[log_file.String()] = true
-  }
+		// Note that we created this rule
+		rules[log_file.String()] = true
+	}
 }
 
 // BuildQuesta will compile and optimize the source and IPs associated with the given
 // rule.
 func BuildQuesta(ctx core.Context, rule Simulation) {
-  // compile the code
-  deps := compile(ctx, rule)
+	// compile the code
+	deps := compile(ctx, rule)
 
-  // optimize the code
-  optimize(ctx, rule, deps)
+	// optimize the code
+	optimize(ctx, rule, deps)
 }
 
 // verbosityLevelToFlag takes a verbosity level of none, low, medium or high and
 // converts it to the corresponding DVM_ level.
 func verbosityLevelToFlag(level string) (string, bool) {
-  var verbosity_flag string
-  var print_output bool
-  switch level {
-  case "none":
-    verbosity_flag = " +verbosity=DVM_VERB_NONE"
-    print_output = false
-  case "low":
-    verbosity_flag = " +verbosity=DVM_VERB_LOW"
-    print_output = true
-  case "medium":
-    verbosity_flag = " +verbosity=DVM_VERB_MED"
-    print_output = true
-  case "high":
-    verbosity_flag = " +verbosity=DVM_VERB_HIGH"
-    print_output = true
-  default:
-    log.Fatal(fmt.Sprintf("invalid verbosity flag '%s', only 'low', 'medium',"+
-      " 'high' or 'none' allowed!", level))
-  }
+	var verbosity_flag string
+	var print_output bool
+	switch level {
+	case "none":
+		verbosity_flag = " +verbosity=DVM_VERB_NONE"
+		print_output = false
+	case "low":
+		verbosity_flag = " +verbosity=DVM_VERB_LOW"
+		print_output = true
+	case "medium":
+		verbosity_flag = " +verbosity=DVM_VERB_MED"
+		print_output = true
+	case "high":
+		verbosity_flag = " +verbosity=DVM_VERB_HIGH"
+		print_output = true
+	default:
+		log.Fatal(fmt.Sprintf("invalid verbosity flag '%s', only 'low', 'medium',"+
+			" 'high' or 'none' allowed!", level))
+	}
 
-  return verbosity_flag, print_output
+	return verbosity_flag, print_output
 }
 
 // preamble creates a preamble for the simulation command for the purpose of generating
 // a testcase.
 func preamble(rule Simulation, testcase string) (string, string) {
-  preamble := ""
+	preamble := ""
 
-  // Create a testcase generation command if necessary
-  if rule.TestCaseGenerator != nil {
-    // No testcase specified, use default
-    if testcase == "" {
-      // If directory of testcases available, pick the first one
-      if rule.TestCasesDir != nil {
-        if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
-          if len(items) == 0 {
-            log.Fatal(fmt.Sprintf("TestCasesDir directory '%s' empty!", rule.TestCasesDir.String()))
-          }
+	// Create a testcase generation command if necessary
+	if rule.TestCaseGenerator != nil {
+		// No testcase specified, use default
+		if testcase == "" {
+			// If directory of testcases available, pick the first one
+			if rule.TestCasesDir != nil {
+				if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
+					if len(items) == 0 {
+						log.Fatal(fmt.Sprintf("TestCasesDir directory '%s' empty!", rule.TestCasesDir.String()))
+					}
 
-          // Create path to testcase
-          testcase = rule.TestCasesDir.Absolute() + "/" + items[0].Name()
-        }
-      }
-    } else if testcase != "" && rule.TestCasesDir != nil {
-      // Create path to testcase
-      testcase = rule.TestCasesDir.Absolute() + "/" + testcase
-    }
+					// Create path to testcase
+					testcase = rule.TestCasesDir.Absolute() + "/" + items[0].Name()
+				}
+			}
+		} else if testcase != "" && rule.TestCasesDir != nil {
+			// Create path to testcase
+			testcase = rule.TestCasesDir.Absolute() + "/" + testcase
+		}
 
-    if testcase == "" {
-      // Create the preamble for testcase generator without any argument
-      preamble = fmt.Sprintf("{ %s . ; }", rule.TestCaseGenerator.String())
-      testcase = "default"
-    } else {
-      // Create the preamble for testcase generator with arguments
-      preamble = fmt.Sprintf("{ %s %s . ; }", rule.TestCaseGenerator.String(), testcase)
-    }
+		if testcase == "" {
+			// Create the preamble for testcase generator without any argument
+			preamble = fmt.Sprintf("{ %s . ; }", rule.TestCaseGenerator.String())
+			testcase = "default"
+		} else {
+			// Create the preamble for testcase generator with arguments
+			preamble = fmt.Sprintf("{ %s %s . ; }", rule.TestCaseGenerator.String(), testcase)
+		}
 
-    // Add information to command
-    preamble = fmt.Sprintf("{ echo Generating %s; } && ", testcase) + preamble
+		// Add information to command
+		preamble = fmt.Sprintf("{ echo Generating %s; } && ", testcase) + preamble
 
-    // Trim testcase for use in coverage databaes
-    testcase = strings.TrimSuffix(path.Base(testcase), path.Ext(testcase))
-  }
+		// Trim testcase for use in coverage databaes
+		testcase = strings.TrimSuffix(path.Base(testcase), path.Ext(testcase))
+	}
 
-  return preamble, testcase
+	return preamble, testcase
 }
 
 // questaCmd will create a command for starting 'vsim' on the compiled and optimized design with flags
 // set in accordance with what is specified on the command line.
 func questaCmd(rule Simulation, args []string, gui bool, testcase string, params string) string {
-  // Prefix the vsim command with this
-  cmd_preamble := ""
+	// Prefix the vsim command with this
+	cmd_preamble := ""
 
-  // Default log file
-  log_file_suffix := "vsim.log"
-  if testcase != "" {
-    log_file_suffix = testcase + "_" + log_file_suffix
-  }
-  if params != "" {
-    log_file_suffix = params + "_" + log_file_suffix
-  }
-  log_file := rule.Path().WithSuffix("/" + log_file_suffix)
+	// Default log file
+	log_file_suffix := "vsim.log"
+	if testcase != "" {
+		log_file_suffix = testcase + "_" + log_file_suffix
+	}
+	if params != "" {
+		log_file_suffix = params + "_" + log_file_suffix
+	}
+	log_file := rule.Path().WithSuffix("/" + log_file_suffix)
 
-  // Default flag values
-  vsim_flags := " -onfinish stop -l " + log_file.String()
-  seed_flag := " -sv_seed random"
-  verbosity_flag := " +verbosity=DVM_VERB_NONE"
-  mode_flag := " -batch -quiet"
-  plusargs_flag := ""
+	// Default flag values
+	vsim_flags := " -onfinish stop -l " + log_file.String()
+	seed_flag := " -sv_seed random"
+	verbosity_flag := " +verbosity=DVM_VERB_NONE"
+	mode_flag := " -batch -quiet"
+	plusargs_flag := ""
 
-  // Enable coverage in simulator
-  coverage_flag := ""
-  if Coverage.Value() {
-    coverage_flag = " -coverage"
-  }
+	// Enable coverage in simulator
+	coverage_flag := ""
+	if Coverage.Value() {
+		coverage_flag = " -coverage"
+	}
 
-  // Determine the names of the coverage databases, this one will hold merged
-  // data from multiple testcases
-  main_coverage_db := rule.Name
+	// Determine the names of the coverage databases, this one will hold merged
+	// data from multiple testcases
+	main_coverage_db := rule.Name
 
-  // This will be the name of the database created by the current run
-  coverage_db := rule.Name
+	// This will be the name of the database created by the current run
+	coverage_db := rule.Name
 
-  // Collect do-files here
-  var do_flags []string
+	// Collect do-files here
+	var do_flags []string
 
-  // Turn off output unless verbosity is activated
-  print_output := false
+	// Turn off output unless verbosity is activated
+	print_output := false
 
-  // Parse additional arguments
-  for _, arg := range args {
-    if strings.HasPrefix(arg, "-seed=") {
-      // Define simulator seed
-      var seed int64
-      if _, err := fmt.Sscanf(arg, "-seed=%d", &seed); err == nil {
-        seed_flag = fmt.Sprintf(" -sv_seed %d", seed)
-      } else {
-        log.Fatal("-seed expects an integer argument!")
-      }
-    } else if strings.HasPrefix(arg, "-verbosity=") {
-      // Define verbosity level
-      var level string
-      if _, err := fmt.Sscanf(arg, "-verbosity=%s", &level); err == nil {
-        verbosity_flag, print_output = verbosityLevelToFlag(level)
-      } else {
-        log.Fatal("-verbosity expects an argument of 'low', 'medium', 'high' or 'none'!")
-      }
-    } else if strings.HasPrefix(arg, "+") {
-      // All '+' arguments go directly to the simulator
-      plusargs_flag = plusargs_flag + " " + arg
-    }
-  }
+	// Parse additional arguments
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-seed=") {
+			// Define simulator seed
+			var seed int64
+			if _, err := fmt.Sscanf(arg, "-seed=%d", &seed); err == nil {
+				seed_flag = fmt.Sprintf(" -sv_seed %d", seed)
+			} else {
+				log.Fatal("-seed expects an integer argument!")
+			}
+		} else if strings.HasPrefix(arg, "-verbosity=") {
+			// Define verbosity level
+			var level string
+			if _, err := fmt.Sscanf(arg, "-verbosity=%s", &level); err == nil {
+				verbosity_flag, print_output = verbosityLevelToFlag(level)
+			} else {
+				log.Fatal("-verbosity expects an argument of 'low', 'medium', 'high' or 'none'!")
+			}
+		} else if strings.HasPrefix(arg, "+") {
+			// All '+' arguments go directly to the simulator
+			plusargs_flag = plusargs_flag + " " + arg
+		}
+	}
 
-  // Create optional command preamble
-  cmd_preamble, testcase = preamble(rule, testcase)
+	// Create optional command preamble
+	cmd_preamble, testcase = preamble(rule, testcase)
 
-  cmd_echo := ""
-  if rule.Params != nil && params != "" {
-    // Update coverage database name based on parameters. We cannot merge
-    // different parameter sets, do we have to make a dedicated main database
-    // for this parameter set.
-    main_coverage_db = main_coverage_db + "_" + params
-    coverage_db = coverage_db + "_" + params
-    cmd_echo = "Testcase " + params
-    
-    // Update with testcase if specified
-    if testcase != "" {
-      coverage_db = coverage_db + "_" + testcase
-      cmd_echo = cmd_echo + "/" + testcase + ":"
-      testcase = params + "_" + testcase
-    } else {
-      cmd_echo = cmd_echo + ":"
-      testcase = params
-    }
-  } else {
-    // Update coverage database name with testcase alone, main database stays
-    // the same
-    if testcase != "" {
-      coverage_db = coverage_db + "_" + testcase
-      cmd_echo = "Testcase " + testcase + ":"
-    } else {
-      testcase = "default"
-    }
-  }
+	cmd_echo := ""
+	if rule.Params != nil && params != "" {
+		// Update coverage database name based on parameters. We cannot merge
+		// different parameter sets, do we have to make a dedicated main database
+		// for this parameter set.
+		main_coverage_db = main_coverage_db + "_" + params
+		coverage_db = coverage_db + "_" + params
+		cmd_echo = "Testcase " + params
 
-  cmd_postamble := ""
-  if gui {
-    mode_flag = " -gui"
-    if rule.WaveformInit != nil {
-      do_flags = append(do_flags, rule.WaveformInit.String())
-    }
-  } else {
-    if !print_output {
-      mode_flag = mode_flag + " -nostdout"
-    }
-    do_flags = append(do_flags, "\"run -all\"")
-    if Coverage.Value() {
-      do_flags = append(do_flags, fmt.Sprintf("\"coverage save -assert"+
-        " -cvg -codeAll -testname %s"+
-        " %s.ucdb\"",
-        testcase, coverage_db))
-      do_flags = append(do_flags, 
-        fmt.Sprintf("\"vcover merge -testassociated -out %s.ucdb %s.ucdb %s.ucdb\"", 
-          main_coverage_db, main_coverage_db, coverage_db))
-      if CoverageHtml.Value() {
-        do_flags = append(do_flags,
-          fmt.Sprintf("\"vcover report -html -output %s_covhtml -testdetails -details -assert"+
-            " -cvg -codeAll %s.ucdb\"", main_coverage_db, main_coverage_db))
-      }
-    }
-    do_flags = append(do_flags, "\"quit -code [coverage attribute -name TESTSTATUS -concise]\"")
-    cmd_newline := ":"
-    if cmd_echo != "" {
-      cmd_newline = "echo"
-    }
-    cmd_postamble = fmt.Sprintf("|| { %s; cat %s; exit 1; }", cmd_newline, log_file.String())
-  }
+		// Update with testcase if specified
+		if testcase != "" {
+			coverage_db = coverage_db + "_" + testcase
+			cmd_echo = cmd_echo + "/" + testcase + ":"
+			testcase = params + "_" + testcase
+		} else {
+			cmd_echo = cmd_echo + ":"
+			testcase = params
+		}
+	} else {
+		// Update coverage database name with testcase alone, main database stays
+		// the same
+		if testcase != "" {
+			coverage_db = coverage_db + "_" + testcase
+			cmd_echo = "Testcase " + testcase + ":"
+		} else {
+			testcase = "default"
+		}
+	}
 
-  vsim_flags = vsim_flags + mode_flag + seed_flag + coverage_flag +
-    verbosity_flag + plusargs_flag + VsimFlags.Value()
+	cmd_postamble := ""
+	if gui {
+		mode_flag = " -gui"
+		if rule.WaveformInit != nil {
+			do_flags = append(do_flags, rule.WaveformInit.String())
+		}
+	} else {
+		if !print_output {
+			mode_flag = mode_flag + " -nostdout"
+		}
+		do_flags = append(do_flags, "\"run -all\"")
+		if Coverage.Value() {
+			do_flags = append(do_flags, fmt.Sprintf("\"coverage save -assert"+
+				" -cvg -codeAll -testname %s"+
+				" %s.ucdb\"",
+				testcase, coverage_db))
+			do_flags = append(do_flags,
+				fmt.Sprintf("\"vcover merge -testassociated -out %s.ucdb %s.ucdb %s.ucdb\"",
+					main_coverage_db, main_coverage_db, coverage_db))
+			if CoverageHtml.Value() {
+				do_flags = append(do_flags,
+					fmt.Sprintf("\"vcover report -html -output %s_covhtml -testdetails -details -assert"+
+						" -cvg -codeAll %s.ucdb\"", main_coverage_db, main_coverage_db))
+			}
+		}
+		do_flags = append(do_flags, "\"quit -code [coverage attribute -name TESTSTATUS -concise]\"")
+		cmd_newline := ":"
+		if cmd_echo != "" {
+			cmd_newline = "echo"
+		}
+		cmd_postamble = fmt.Sprintf("|| { %s; cat %s; exit 1; }", cmd_newline, log_file.String())
+	}
 
-  for _, do_flag := range do_flags {
-    vsim_flags = vsim_flags + " -do " + do_flag
-  }
+	vsim_flags = vsim_flags + mode_flag + seed_flag + coverage_flag +
+		verbosity_flag + plusargs_flag + VsimFlags.Value()
 
-  cmd := fmt.Sprintf("{ echo -n %s && vsim %s -work %s %s && echo PASS; }", cmd_echo, vsim_flags, rule.Lib(), rule.Target()+params)
-  if cmd_preamble == "" {
-    cmd = cmd + " " + cmd_postamble
-  } else {
-    cmd = "{ { " + cmd_preamble + " } && " + cmd + " } " + cmd_postamble
-  }
+	for _, do_flag := range do_flags {
+		vsim_flags = vsim_flags + " -do " + do_flag
+	}
 
-  // Wrap command in another layer of {} to enable chaining
-  cmd = "{ " + cmd + " }"
+	cmd := fmt.Sprintf("{ echo -n %s && vsim %s -work %s %s && echo PASS; }", cmd_echo, vsim_flags, rule.Lib(), rule.Target()+params)
+	if cmd_preamble == "" {
+		cmd = cmd + " " + cmd_postamble
+	} else {
+		cmd = "{ { " + cmd_preamble + " } && " + cmd + " } " + cmd_postamble
+	}
 
-  return cmd
+	// Wrap command in another layer of {} to enable chaining
+	cmd = "{ " + cmd + " }"
+
+	return cmd
 }
 
 // simulateQuesta will create a command to start 'vsim' on the compiled design
@@ -485,84 +485,84 @@ func questaCmd(rule Simulation, args []string, gui bool, testcase string, params
 // optionally build a chain of commands in case the rule has parameters, but
 // no parameters are specified on the command line
 func simulateQuesta(rule Simulation, args []string, gui bool) string {
-  // Optional testcase goes here
-  testcases := []string{}
+	// Optional testcase goes here
+	testcases := []string{}
 
-  // Optional parameter set goes here
-  params := []string{}
+	// Optional parameter set goes here
+	params := []string{}
 
-  // Parse additional arguments
-  for _, arg := range args {
-    if strings.HasPrefix(arg, "-testcase=") && rule.TestCaseGenerator != nil {
-      var testcase string
-      if _, err := fmt.Sscanf(arg, "-testcase=%s", &testcase); err != nil {
-        log.Fatal(fmt.Sprintf("-testcase expects a string argument!"))
-      }
-      testcases = append(testcases, testcase)
-    } else if strings.HasPrefix(arg, "-params=") && rule.Params != nil {
-      var param string
-      if _, err := fmt.Sscanf(arg, "-params=%s", &param); err != nil {
-        log.Fatal(fmt.Sprintf("-params expects a string argument!"))
-      } else {
-        if _, ok := rule.Params[param]; !ok {
-          log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!", param, rule.Name))
-        }
-        params = append(params, param)
-      }
-    }
-  }
+	// Parse additional arguments
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-testcase=") && rule.TestCaseGenerator != nil {
+			var testcase string
+			if _, err := fmt.Sscanf(arg, "-testcase=%s", &testcase); err != nil {
+				log.Fatal(fmt.Sprintf("-testcase expects a string argument!"))
+			}
+			testcases = append(testcases, testcase)
+		} else if strings.HasPrefix(arg, "-params=") && rule.Params != nil {
+			var param string
+			if _, err := fmt.Sscanf(arg, "-params=%s", &param); err != nil {
+				log.Fatal(fmt.Sprintf("-params expects a string argument!"))
+			} else {
+				if _, ok := rule.Params[param]; !ok {
+					log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!", param, rule.Name))
+				}
+				params = append(params, param)
+			}
+		}
+	}
 
-  // If no parameters have been specified, simulate them all
-  if rule.Params != nil && len(params) == 0 {
-    for key := range rule.Params {
-      params = append(params, key)
-    }
-  } else if len(params) == 0 {
-    params = append(params, "")
-  }
+	// If no parameters have been specified, simulate them all
+	if rule.Params != nil && len(params) == 0 {
+		for key := range rule.Params {
+			params = append(params, key)
+		}
+	} else if len(params) == 0 {
+		params = append(params, "")
+	}
 
-  // If no testcase has been specified, simulate them all
-  if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil && len(testcases) == 0 {
-    // Loop through all defined testcases in directory
-    if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
-      for _, item := range items {
-        testcases = append(testcases, item.Name())
-      }
-    } else {
-      log.Fatal(err)
-    }
-  } else if len(testcases) == 0 {
-    testcases = append(testcases, "")
-  }
+	// If no testcase has been specified, simulate them all
+	if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil && len(testcases) == 0 {
+		// Loop through all defined testcases in directory
+		if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
+			for _, item := range items {
+				testcases = append(testcases, item.Name())
+			}
+		} else {
+			log.Fatal(err)
+		}
+	} else if len(testcases) == 0 {
+		testcases = append(testcases, "")
+	}
 
-  // Final command
-  cmd := "{ :; }"
+	// Final command
+	cmd := "{ :; }"
 
-  // Loop for all parameter sets
-  for i := range params {
-    // Loop for all test cases
-    for j := range testcases {
-      cmd = cmd + " && " + questaCmd(rule, args, gui, testcases[j], params[i])
-      // Only one testcase allowed in GUI mode
-      if gui {
-        break
-      }
-    }
-    // Only one parameter set allowed in gui mode
-    if gui {
-      break
-    }
-  }
+	// Loop for all parameter sets
+	for i := range params {
+		// Loop for all test cases
+		for j := range testcases {
+			cmd = cmd + " && " + questaCmd(rule, args, gui, testcases[j], params[i])
+			// Only one testcase allowed in GUI mode
+			if gui {
+				break
+			}
+		}
+		// Only one parameter set allowed in gui mode
+		if gui {
+			break
+		}
+	}
 
-  return cmd
+	return cmd
 }
 
 // Run will build the design and run a simulation in GUI mode.
 func RunQuesta(rule Simulation, args []string) string {
-  return simulateQuesta(rule, args, true)
+	return simulateQuesta(rule, args, true)
 }
 
 // Test will build the design and run a simulation in batch mode.
 func TestQuesta(rule Simulation, args []string) string {
-  return simulateQuesta(rule, args, false)
+	return simulateQuesta(rule, args, false)
 }

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -16,6 +16,7 @@ var VlogFlags = core.StringFlag{
 	DefaultFn: func() string {
 		return ""
 	},
+	Description: "Extra flags for the vlog command",
 }.Register()
 
 // VcomFlags enables the user to specify additional flags for the 'vcom' command.
@@ -24,6 +25,7 @@ var VcomFlags = core.StringFlag{
 	DefaultFn: func() string {
 		return ""
 	},
+	Description: "Extra flags for the vcom command",
 }.Register()
 
 // VsimFlags enables the user to specify additional flags for the 'vsim' command.
@@ -32,6 +34,7 @@ var VsimFlags = core.StringFlag{
 	DefaultFn: func() string {
 		return ""
 	},
+	Description: "Extra flags for the vsim command",
 }.Register()
 
 // Access enables the user to control the accessibility in the compiled design for
@@ -41,6 +44,7 @@ var Access = core.StringFlag{
 	DefaultFn: func() string {
 		return "rna"
 	},
+	Description: "Control access to simulation objects for debugging purposes",
 }.Register()
 
 // Coverage enables the user to run the simulation with code coverage.
@@ -49,6 +53,7 @@ var Coverage = core.BoolFlag{
 	DefaultFn: func() bool {
 		return false
 	},
+	Description: "Enable code-coverage database generation",
 }.Register()
 
 // CoverageHtml enables the generation of an Html report in the output directory
@@ -57,6 +62,7 @@ var CoverageHtml = core.BoolFlag{
 	DefaultFn: func() bool {
 		return false
 	},
+	Description: "Enable code-coverage HTML report generation",
 }.Register()
 
 // Target returns the optimization target name defined for this rule.

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -2,75 +2,300 @@ package hdl
 
 import (
 	"fmt"
+	"path"
+	"strings"
+	"log"
 
 	"dbt-rules/RULES/core"
-	"dbt-rules/hdl"
 )
 
-type QuestaSimScriptParams struct {
-	Name         string
-	PartName     string
-	BoardName    string
-	OutDir       core.Path
-	OutScript    core.Path
-	OutSimScript core.Path
-	IncDir       core.Path
-	Srcs         []core.Path
-	Ips          []core.Path
-	Libs         []string
-	LibDir       string
-	Verbose      bool
-}
+// VlogFlags enables the user to specify additional flags for the 'vlog' command.
+var VlogFlags = core.StringFlag{
+	Name: "questa-vlog-flags",
+	DefaultFn: func() string {
+		return ""
+	},
+}.Register()
+
+// VcomFlags enables the user to specify additional flags for the 'vcom' command.
+var VcomFlags = core.StringFlag{
+	Name: "questa-vcom-flags",
+	DefaultFn: func() string {
+		return ""
+	},
+}.Register()
+
+// Access enables the user to control the accessibility in the compiled design for
+// debugging purposes.
+var Access = core.StringFlag{
+	Name: "questa-access",
+	DefaultFn: func() string {
+		return "rna"
+	},
+}.Register()
+
+// Coverage enables the user to run the simulation with code coverage.
+var Coverage = core.BoolFlag{
+	Name: "questa-coverage",
+	DefaultFn: func() bool {
+		return false
+	},
+}.Register()
 
 type SimulationQuesta struct {
 	Name    string
 	Srcs    []core.Path
 	Ips     []Ip
 	Libs    []string
-	Verbose bool
+	Params  []string
+	Top     string
 }
 
-func (rule SimulationQuesta) Build(ctx core.Context) {
-	outDir := ctx.Cwd().WithSuffix("/" + rule.Name)
-	outScript := outDir.WithSuffix(".sh")
-	outSimScript := outDir.WithSuffix(".questa.do")
+// Lib returns the standard Questa library name defined for this rule.
+func (rule SimulationQuesta) Lib() string {
+	return rule.Name + "Lib"
+}
 
-	ins := []core.Path{}
-	srcs := []core.Path{}
-	ips := []core.Path{}
+// Target returns the optimization target name defined for this rule.
+func (rule SimulationQuesta) Target() string {
+	if Coverage.Value() {
+		return rule.Name + "Cov"
+	} else {
+		return rule.Name
+	}
+}
 
-	for _, ip := range FlattenIpGraph(rule.Ips) {
-		for _, src := range ip.Sources() {
-			if IsSimulationArchive(src.String()) {
-				ips = append(ips, src)
-			} else if IsRtl(src.String()) {
-				srcs = append(srcs, src)
+// Path returns the default root path for log files defined for this rule.
+func (rule SimulationQuesta) Path() core.Path {
+	return core.BuildPath("/" + rule.Name)
+}
+
+// rules holds a map of all defined rules to prevent defining the same rule
+// multiple times.
+var rules = make(map[string]bool)
+
+// common_flags holds common flags used for the 'vlog', 'vcom', 'vopt' and 'vsim' commands.
+const common_flags = "-nologo -quiet"
+
+// CompileSrcs compiles a list of sources using the specified context ctx, rule,
+// dependencies and include paths. It returns the resulting dependencies and include paths
+// that result from compiling the source files.
+func CompileSrcs(ctx core.Context, rule SimulationQuesta, 
+	               deps []core.Path, incs []core.Path, srcs []core.Path) ([]core.Path, []core.Path) {
+	for _, src := range srcs {
+		// We handle header files separately from other source files
+		if IsHeader(src.String()) {
+			incs = append(incs, src)
+		} else if IsRtl(src.String()) {
+			// log will point to the log file to be generated when compiling the code
+			log := rule.Path().WithSuffix("/" + src.Relative() + ".log")
+
+			// If we already have a rule for this file, skip it.
+			if rules[log.String()] {
+				continue
 			}
-			ins = append(ins, src)
+
+			// Holds common flags for both 'vlog' and 'vcom' commands
+			cmd := fmt.Sprintf("%s +acc=%s -work %s -l %s", common_flags, Access.Value(), rule.Lib(), log.String())
+			
+			// tool will point to the tool to execute (also used for logging below)
+			var tool string
+			if IsVerilog(src.String()) {
+				tool = "vlog"
+				cmd = cmd + " " + VlogFlags.Value()
+				cmd = cmd + " -suppress 2583 -svinputport=net"
+				cmd = cmd + fmt.Sprintf(" +incdir+%s", core.SourcePath("").String())
+				for _, inc := range incs {
+					cmd = cmd + fmt.Sprintf(" +incdir+%s", path.Dir(inc.Absolute()))
+				}
+			} else if IsVhdl(src.String()) {
+				tool = "vcom"
+			}
+			
+			// Remove the log file if the command fails to ensure we can recompile it
+			cmd = tool + " " + cmd + " " + src.String() + " || rm " + log.String()
+			
+			// Add the compilation command as a build step with the log file as the
+			// generated output
+			ctx.AddBuildStep(core.BuildStep{
+				Out:   log,
+				Ins:   deps,
+				Cmd:   cmd,
+				Descr: fmt.Sprintf("%s: %s", tool, path.Base(src.String())),
+			})
+			
+			// Add the log file to the dependencies of the next files
+			deps = append(deps, log)
+
+			// Note down the created rule
+			rules[log.String()] = true
+		}	
+	}
+
+	return deps, incs
+}
+
+// CompileIp compiles the IP dependencies and the source files and an IP.
+func CompileIp(ctx core.Context, rule SimulationQuesta, ip Ip, 
+	             deps []core.Path, incs []core.Path) ([]core.Path, []core.Path) {
+	for _, sub_ip := range ip.Ips() {
+		deps, incs = CompileIp(ctx, rule, sub_ip, deps, incs)
+	}
+	deps, incs = CompileSrcs(ctx, rule, deps, incs, ip.Sources())
+
+	return deps, incs
+}
+
+// Compile compiles the IP dependencies and source files of a simulation rule.
+func Compile(ctx core.Context, rule SimulationQuesta) []core.Path {
+	incs := []core.Path{}
+	deps := []core.Path{}
+
+	for _, ip := range rule.Ips {
+		deps, incs = CompileIp(ctx, rule, ip, deps, incs)
+	}
+	CompileSrcs(ctx, rule, deps, incs, rule.Srcs)
+
+	return deps
+}
+
+// Optimize creates and optimized version of the design optionally including
+// coverage recording functionality. The optimized design unit can then conveniently
+// be simulated using 'vsim'.
+func Optimize(ctx core.Context, rule SimulationQuesta, deps []core.Path) {
+	top := "board"
+	if rule.Top != "" {
+		top = rule.Top
+	}
+	
+	log := rule.Path().WithSuffix("/vopt.log")
+	cover_flag := ""
+	if Coverage.Value() {
+		log = rule.Path().WithSuffix("/vopt_cover.log")
+		cover_flag = "+cover"
+	}
+
+	// Skip if we already have a rule
+	if rules[log.String()] {
+		return
+	}
+
+	cmd := fmt.Sprintf("vopt %s %s +acc=%s -l %s -work %s %s -o %s", 
+	                   common_flags, cover_flag, Access.Value(),
+	                   log.String(), rule.Lib(), top, rule.Target())
+
+	// Add parameters for all generics
+	for _, param := range rule.Params {
+		cmd = cmd + " -G " + param
+	}
+	
+	// Add the rule to run 'vopt'.
+	ctx.AddBuildStep(core.BuildStep{
+		Out:   log,
+		Ins:   deps,
+		Cmd:   cmd,
+		Descr: fmt.Sprintf("vopt: %s", rule.Lib() + "." + top),
+	})
+
+	// Note that we created this rule
+	rules[log.String()] = true
+}
+
+// CreateLib creates a Questa simulation library named after the rule with the
+// suffix "Lib" added. It also adds the base name where source code will be
+// compiled to the global list of created rules after it has added the
+// build step for the library.
+func CreateLib(ctx core.Context, rule SimulationQuesta) {
+	path := rule.Path()
+
+	// Skip if we already know this rule
+	if rules[path.String()] {
+		return
+	}
+
+	// Add the rule to run 'vlib'
+	ctx.AddBuildStep(core.BuildStep{
+		Out:   path.WithSuffix("Lib"),
+		Cmd:   fmt.Sprintf("vlib %s", rule.Lib()),
+		Descr: fmt.Sprintf("vlib: %s", rule.Lib()),
+	})
+
+	// Remember that we created this rule
+	rules[path.String()] = true
+}
+
+// Build will compile and optimize the source and IPs associated with the given
+// rule.
+func (rule SimulationQuesta) Build(ctx core.Context) {
+	// Create the library
+	CreateLib(ctx, rule)
+
+	// Compile the code
+	deps := Compile(ctx, rule)
+
+	// Optimize the code
+	Optimize(ctx, rule, deps)
+}
+
+// Simulate will start 'vsim' on the compiled design with flags set in accordance
+// with what is specified on the command line.
+func Simulate(args []string, gui bool, rule SimulationQuesta) string {
+	vsim_flags := ""
+	seed_flag := " -sv_seed random"
+	verbosity_flag := " +verbosity=DVM_VERB_NONE"
+	testcases_flag := " +testcases=__all__"
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-seed=") {
+			var seed int64
+			if _, err := fmt.Sscanf(arg, "-seed=%d", &seed); err == nil {
+				seed_flag = fmt.Sprintf(" -sv_seed %d", seed)
+			} else {
+				log.Fatal("-seed expects an integer argument!")
+			}
+		} else if strings.HasPrefix(arg, "-verbosity=") {
+			var level string
+			if _, err := fmt.Sscanf(arg, "-verbosity=%s", &level); err == nil {
+				switch level {
+				case "none":   verbosity_flag = " +verbosity=DVM_VERB_NONE"
+				case "low":    verbosity_flag = " +verbosity=DVM_VERB_LOW"
+				case "medium": verbosity_flag = " +verbosity=DVM_VERB_MED"
+				case "high":   verbosity_flag = " +verbosity=DVM_VERB_HIGH"
+				}
+			} else {
+				log.Fatal("-verbosity expects an argument of 'low', 'medium', 'high' or 'none'!")
+			}
+		}	else if strings.HasPrefix(arg, "-testcases=") {
+			var testcases string
+			if _, err := fmt.Sscanf(arg, "-testcases=%s", &testcases); err == nil {
+				testcases_flag = " +testcases=" + testcases		
+			} else {
+				log.Fatal("-testcases expects a string argument!")
+			}
 		}
 	}
-	srcs = append(srcs, rule.Srcs...)
-	ins = append(ins, rule.Srcs...)
 
-	data := QuestaSimScriptParams{
-		PartName:     PartName.Value(),
-		BoardName:    BoardName.Value(),
-		Name:         rule.Name,
-		OutDir:       outDir,
-		OutScript:    outScript,
-		OutSimScript: outSimScript,
-		IncDir:       core.SourcePath(""),
-		Srcs:         srcs,
-		Ips:          ips,
-		Libs:         rule.Libs,
-		LibDir:       SimulatorLibDir.Value(),
-		Verbose:      rule.Verbose,
+	log := rule.Path().WithSuffix("/vsim.log")
+	vsim_flags = vsim_flags + seed_flag + verbosity_flag + testcases_flag + " -onfinish stop" +
+	             " -l " + log.String()
+
+	cmd_extra := "" 
+	if gui {
+		vsim_flags = vsim_flags + " -gui"
+	} else {
+		vsim_flags = vsim_flags + " -batch -nostdout -quiet -do \"run -all; quit -code [coverage attribute -name TESTSTATUS -concise]\""
+		cmd_extra = fmt.Sprintf("|| { cat %s; exit 1; }", log.String())
 	}
 
-	ctx.AddBuildStep(core.BuildStep{
-		Outs:   []core.OutPath{outDir, outScript, outSimScript},
-		Ins:    ins,
-		Script: core.CompileTemplateFile(hdl.QuestaSimScriptTmpl.String(), data),
-		Descr:  fmt.Sprintf("Generating Questa simulation %s", outScript.Relative()),
-	})
+	return fmt.Sprintf("vsim %s -work %s %s %s", vsim_flags, rule.Lib(), 
+	                    rule.Target(), cmd_extra)
+}
+
+// Run will build the design and run a simulation in GUI mode.
+func (rule SimulationQuesta) Run(args []string) string {
+	return Simulate(args, true, rule)
+}
+
+// Test will build the design and run a simulation in batch mode.
+func (rule SimulationQuesta) Test(args []string) string {
+	return Simulate(args, false, rule)
 }

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -68,9 +68,9 @@ var CoverageHtml = core.BoolFlag{
 // Target returns the optimization target name defined for this rule.
 func (rule Simulation) Target() string {
 	if Coverage.Value() {
-		return rule.Name + "_OptCov"
+		return rule.Name + "_optcov"
 	} else {
-		return rule.Name + "_Opt"
+		return rule.Name + "_opt"
 	}
 }
 
@@ -137,7 +137,7 @@ func compileSrcs(ctx core.Context, rule Simulation,
 			}
 
 			// Remove the log file if the command fails to ensure we can recompile it
-			cmd = tool + " " + cmd + " " + src.String() + " || rm " + log.String()
+			cmd = tool + " " + cmd + " " + src.String() + " || { rm " + log.String() + " && exit 1; }"
 
 			// Add the compilation command as a build step with the log file as the
 			// generated output

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -236,9 +236,6 @@ func optimize(ctx core.Context, rule Simulation, deps []core.Path) {
 				for param, value := range params {
 					cmd = fmt.Sprintf("%s -G %s=%s", cmd, param, value)
 				}
-			} else {
-				log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!",
-					params, rule.Name))
 			}
 		}
 
@@ -510,10 +507,9 @@ func simulateQuesta(rule Simulation, args []string, gui bool) string {
 			if _, err := fmt.Sscanf(arg, "-params=%s", &param); err != nil {
 				log.Fatal(fmt.Sprintf("-params expects a string argument!"))
 			} else {
-				if _, ok := rule.Params[param]; !ok {
-					log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!", param, rule.Name))
+				if _, ok := rule.Params[param]; ok {
+					params = append(params, param)
 				}
-				params = append(params, param)
 			}
 		}
 	}

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -83,7 +83,7 @@ func (rule Simulation) Test(args []string) string {
 
 func (rule Simulation) Description() string {
   // Print the rule name as its needed for parameter selection
-  description := " Name: " + rule.Name + " "
+  description := " "
   first := true
   for param, _ := range rule.Params {
     if first {

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -39,16 +39,20 @@ type Simulation struct {
   WaveformInit      core.Path
 }
 
+// Lib returns the standard library name defined for this rule.
+func (rule Simulation) Lib() string {
+  return rule.Name + "Lib"
+}
+
+// Path returns the default root path for log files defined for this rule.
+func (rule Simulation) Path() core.Path {
+  return core.BuildPath("/" + rule.Name)
+}
+
 func (rule Simulation) Build(ctx core.Context) {
   switch Simulator.Value() {
   case "xsim":
-    SimulationXsim{
-      Name:    rule.Name,
-      Srcs:    rule.Srcs,
-      Ips:     rule.Ips,
-      Libs:    rule.Libs,
-      Verbose: false,
-    }.Build(ctx)
+    BuildXsim(ctx, rule)
   case "questa":
     BuildQuesta(ctx, rule)
   default:
@@ -60,6 +64,8 @@ func (rule Simulation) Run(args []string) string {
   res := ""
 
   switch Simulator.Value() {
+  case "xsim":
+    res = RunXsim(rule, args)
   case "questa":
     res = RunQuesta(rule, args)
   default:
@@ -72,6 +78,8 @@ func (rule Simulation) Run(args []string) string {
 func (rule Simulation) Test(args []string) string {
   res := ""
   switch Simulator.Value() {
+  case "xsim":
+    res = TestXsim(rule, args)
   case "questa":
     res = TestQuesta(rule, args)
   default:

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -24,14 +24,6 @@ var SimulatorLibDir = core.StringFlag{
 	},
 }.Register()
 
-var SimulatorParams = core.StringFlag{
-	Name:        "hdl-simulator-params",
-	Description: "Name of the parameter set to use",
-	DefaultFn: func() string {
-		return "default"
-	},
-}.Register()
-
 type ParamMap map[string]map[string]string
 
 type Simulation struct {

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -1,110 +1,110 @@
 package hdl
 
 import (
-	"log"
-	"fmt"
-	"os"
-	"dbt-rules/RULES/core"
+  "log"
+  "fmt"
+  "os"
+  "dbt-rules/RULES/core"
 )
 
 var Simulator = core.StringFlag{
-	Name:        "hdl-simulator",
-	Description: "HDL simulator to use when generating simulation targets",
-	DefaultFn: func() string {
-		return "questa"
-	},
-	AllowedValues: []string{"xsim", "questa"},
+  Name:        "hdl-simulator",
+  Description: "HDL simulator to use when generating simulation targets",
+  DefaultFn: func() string {
+    return "questa"
+  },
+  AllowedValues: []string{"xsim", "questa"},
 }.Register()
 
 var SimulatorLibDir = core.StringFlag{
-	Name:        "hdl-simulator-lib-dir",
-	Description: "Path to the HDL Simulator libraries",
-	DefaultFn: func() string {
-		return ""
-	},
+  Name:        "hdl-simulator-lib-dir",
+  Description: "Path to the HDL Simulator libraries",
+  DefaultFn: func() string {
+    return ""
+  },
 }.Register()
 
 type ParamMap map[string]map[string]string
 
 type Simulation struct {
-	Name              string
-	Srcs              []core.Path
-	Ips               []Ip
-	Libs              []string
-	Params            ParamMap
-	Top               string
-	Dut               string
-	TestCaseGenerator core.Path
-	TestCasesDir      core.Path
-	WaveformInit      core.Path
+  Name              string
+  Srcs              []core.Path
+  Ips               []Ip
+  Libs              []string
+  Params            ParamMap
+  Top               string
+  Dut               string
+  TestCaseGenerator core.Path
+  TestCasesDir      core.Path
+  WaveformInit      core.Path
 }
 
 func (rule Simulation) Build(ctx core.Context) {
-	switch Simulator.Value() {
-	case "xsim":
-		SimulationXsim{
-			Name:    rule.Name,
-			Srcs:    rule.Srcs,
-			Ips:     rule.Ips,
-			Libs:    rule.Libs,
-			Verbose: false,
-		}.Build(ctx)
-	case "questa":
-		BuildQuesta(ctx, rule)
-	default:
-		log.Fatal(fmt.Sprintf("invalid value '%s' for hdl-simulator flag", Simulator.Value()))
-	}
+  switch Simulator.Value() {
+  case "xsim":
+    SimulationXsim{
+      Name:    rule.Name,
+      Srcs:    rule.Srcs,
+      Ips:     rule.Ips,
+      Libs:    rule.Libs,
+      Verbose: false,
+    }.Build(ctx)
+  case "questa":
+    BuildQuesta(ctx, rule)
+  default:
+    log.Fatal(fmt.Sprintf("invalid value '%s' for hdl-simulator flag", Simulator.Value()))
+  }
 }
 
 func (rule Simulation) Run(args []string) string {
-	res := ""
+  res := ""
 
-	switch Simulator.Value() {
-	case "questa":
-		res = RunQuesta(rule, args)
-	default:
-		log.Fatal(fmt.Sprintf("'run' target not supported for hdl-simulator flag '%s'", Simulator.Value()))
-	}
+  switch Simulator.Value() {
+  case "questa":
+    res = RunQuesta(rule, args)
+  default:
+    log.Fatal(fmt.Sprintf("'run' target not supported for hdl-simulator flag '%s'", Simulator.Value()))
+  }
 
-	return res
+  return res
 }
 
 func (rule Simulation) Test(args []string) string {
-	res := ""
-	switch Simulator.Value() {
-	case "questa":
-		res = TestQuesta(rule, args)
-	default:
-		log.Fatal(fmt.Sprintf("'test' target not supported for hdl-simulator flag '%s'", Simulator.Value()))
-	}
+  res := ""
+  switch Simulator.Value() {
+  case "questa":
+    res = TestQuesta(rule, args)
+  default:
+    log.Fatal(fmt.Sprintf("'test' target not supported for hdl-simulator flag '%s'", Simulator.Value()))
+  }
 
-	return res
+  return res
 }
 
 func (rule Simulation) Description() string {
-	// Print the rule name as its needed for parameter selection
-	description := " Name: " + rule.Name + " "
-	first := true
-	for param, _ := range(rule.Params) {
-		if first {
-			description = description + "Params: "
-			first = false
-		}
-		description = description + param + " "
-	}
+  // Print the rule name as its needed for parameter selection
+  description := " Name: " + rule.Name + " "
+  first := true
+  for param, _ := range(rule.Params) {
+    if first {
+      description = description + "Params: "
+      first = false
+    }
+    description = description + param + " "
+  }
 
-	if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil {
-		description = description + "TestCases: "
-		
-		// Loop through all defined testcases in directory
-		if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
-			for _, item := range items {
+  if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil {
+    description = description + "TestCases: "
+    
+    // Loop through all defined testcases in directory
+    if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
+      for _, item := range items {
         description = description + item.Name() + " "
-			}
-		} else {
-			log.Fatal(err)
-		}
-	}
+      }
+    } else {
+      log.Fatal(err)
+    }
+  }
 
-	return description
+  return description
 }

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -1,6 +1,7 @@
 package hdl
 
 import (
+	"log"
 	"dbt-rules/RULES/core"
 )
 
@@ -26,25 +27,69 @@ type Simulation struct {
 	Srcs    []core.Path
 	Ips     []Ip
 	Libs    []string
-	Verbose bool
+	Params  []string
+	Top     string
 }
 
 func (rule Simulation) Build(ctx core.Context) {
-	if Simulator.Value() == "xsim" {
+	switch Simulator.Value() {
+	case "xsim":
 		SimulationXsim{
 			Name:    rule.Name,
 			Srcs:    rule.Srcs,
 			Ips:     rule.Ips,
 			Libs:    rule.Libs,
-			Verbose: rule.Verbose,
+			Verbose: false,
 		}.Build(ctx)
-	} else {
+	case "questa":
 		SimulationQuesta{
 			Name:    rule.Name,
 			Srcs:    rule.Srcs,
 			Ips:     rule.Ips,
 			Libs:    rule.Libs,
-			Verbose: rule.Verbose,
+			Params:  rule.Params,
+			Top:     rule.Top,
 		}.Build(ctx)
+	default:
+		log.Fatal("invalid value '%s' for hdl-simulator flag", Simulator.Value())
 	}
+}
+
+func (rule Simulation) Run(args []string) string {
+	res := ""
+
+	switch Simulator.Value() {
+	case "questa":
+		res = SimulationQuesta{
+			Name:    rule.Name,
+			Srcs:    rule.Srcs,
+			Ips:     rule.Ips,
+			Libs:    rule.Libs,
+			Params:  rule.Params,
+			Top:     rule.Top,
+		}.Run(args)
+	default:
+		log.Fatal("'run' target not supported for hdl-simulator flag '%s'", Simulator.Value())
+	}
+
+	return res
+}
+
+func (rule Simulation) Test(args []string) string {
+	res := ""
+	switch Simulator.Value() {
+	case "questa":
+		res = SimulationQuesta{
+			Name:    rule.Name,
+			Srcs:    rule.Srcs,
+			Ips:     rule.Ips,
+			Libs:    rule.Libs,
+			Params:  rule.Params,
+			Top:     rule.Top,
+		}.Test(args)
+	default:
+		log.Fatal("'test' target not supported for hdl-simulator flag '%s'", Simulator.Value())
+	}
+
+	return res
 }

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -11,7 +11,7 @@ var Simulator = core.StringFlag{
 	Name:        "hdl-simulator",
 	Description: "HDL simulator to use when generating simulation targets",
 	DefaultFn: func() string {
-		return "xsim"
+		return "questa"
 	},
 	AllowedValues: []string{"xsim", "questa"},
 }.Register()
@@ -90,6 +90,7 @@ func (rule Simulation) Test(args []string) string {
 }
 
 func (rule Simulation) Description() string {
+	// Print the rule name as its needed for parameter selection
 	description := " Name: " + rule.Name + " "
 	first := true
 	for param, _ := range(rule.Params) {
@@ -102,31 +103,15 @@ func (rule Simulation) Description() string {
 
 	if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil {
 		description = description + "TestCases: "
+		
 		// Loop through all defined testcases in directory
-		items, err := os.ReadDir(rule.TestCasesDir.String())
-		if err != nil {
+		if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
+			for _, item := range items {
+        description = description + item.Name() + " "
+			}
+		} else {
 			log.Fatal(err)
 		}
-
-    for _, item := range items {
-			// Handle one level of subdirectories
-			if item.IsDir() {
-				subitems, err := os.ReadDir(item.Name())
-				if err != nil {
-					log.Fatal(err)
-				}
-				
-				for _, subitem := range subitems {
-						if !subitem.IsDir() {
-								// handle file there
-								description = description + item.Name() + "/" + subitem.Name() + " "
-						}
-				}
-			} else {
-        // handle file there
-        description = description + item.Name() + " "
-      }
-    }
 	}
 
 	return description

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -41,7 +41,7 @@ type Simulation struct {
 
 // Lib returns the standard library name defined for this rule.
 func (rule Simulation) Lib() string {
-	return rule.Name + "Lib"
+	return rule.Name + "_lib"
 }
 
 // Path returns the default root path for log files defined for this rule.

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -9,7 +9,7 @@ import (
 
 var Simulator = core.StringFlag{
 	Name:        "hdl-simulator",
-	Description: "HDL simulator to use when generating simulation targets",
+	Description: "Select HDL simulator",
 	DefaultFn: func() string {
 		return "questa"
 	},
@@ -18,7 +18,7 @@ var Simulator = core.StringFlag{
 
 var SimulatorLibDir = core.StringFlag{
 	Name:        "hdl-simulator-lib-dir",
-	Description: "Path to the HDL Simulator libraries",
+	Description: "Path to the HDL simulator libraries",
 	DefaultFn: func() string {
 		return ""
 	},

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -1,118 +1,118 @@
 package hdl
 
 import (
-  "dbt-rules/RULES/core"
-  "fmt"
-  "log"
-  "os"
+	"dbt-rules/RULES/core"
+	"fmt"
+	"log"
+	"os"
 )
 
 var Simulator = core.StringFlag{
-  Name:        "hdl-simulator",
-  Description: "HDL simulator to use when generating simulation targets",
-  DefaultFn: func() string {
-    return "questa"
-  },
-  AllowedValues: []string{"xsim", "questa"},
+	Name:        "hdl-simulator",
+	Description: "HDL simulator to use when generating simulation targets",
+	DefaultFn: func() string {
+		return "questa"
+	},
+	AllowedValues: []string{"xsim", "questa"},
 }.Register()
 
 var SimulatorLibDir = core.StringFlag{
-  Name:        "hdl-simulator-lib-dir",
-  Description: "Path to the HDL Simulator libraries",
-  DefaultFn: func() string {
-    return ""
-  },
+	Name:        "hdl-simulator-lib-dir",
+	Description: "Path to the HDL Simulator libraries",
+	DefaultFn: func() string {
+		return ""
+	},
 }.Register()
 
 type ParamMap map[string]map[string]string
 
 type Simulation struct {
-  Name              string
-  Srcs              []core.Path
-  Ips               []Ip
-  Libs              []string
-  Params            ParamMap
-  Top               string
-  Dut               string
-  TestCaseGenerator core.Path
-  TestCasesDir      core.Path
-  WaveformInit      core.Path
+	Name              string
+	Srcs              []core.Path
+	Ips               []Ip
+	Libs              []string
+	Params            ParamMap
+	Top               string
+	Dut               string
+	TestCaseGenerator core.Path
+	TestCasesDir      core.Path
+	WaveformInit      core.Path
 }
 
 // Lib returns the standard library name defined for this rule.
 func (rule Simulation) Lib() string {
-  return rule.Name + "Lib"
+	return rule.Name + "Lib"
 }
 
 // Path returns the default root path for log files defined for this rule.
 func (rule Simulation) Path() core.Path {
-  return core.BuildPath("/" + rule.Name)
+	return core.BuildPath("/" + rule.Name)
 }
 
 func (rule Simulation) Build(ctx core.Context) {
-  switch Simulator.Value() {
-  case "xsim":
-    BuildXsim(ctx, rule)
-  case "questa":
-    BuildQuesta(ctx, rule)
-  default:
-    log.Fatal(fmt.Sprintf("invalid value '%s' for hdl-simulator flag", Simulator.Value()))
-  }
+	switch Simulator.Value() {
+	case "xsim":
+		BuildXsim(ctx, rule)
+	case "questa":
+		BuildQuesta(ctx, rule)
+	default:
+		log.Fatal(fmt.Sprintf("invalid value '%s' for hdl-simulator flag", Simulator.Value()))
+	}
 }
 
 func (rule Simulation) Run(args []string) string {
-  res := ""
+	res := ""
 
-  switch Simulator.Value() {
-  case "xsim":
-    res = RunXsim(rule, args)
-  case "questa":
-    res = RunQuesta(rule, args)
-  default:
-    log.Fatal(fmt.Sprintf("'run' target not supported for hdl-simulator flag '%s'", Simulator.Value()))
-  }
+	switch Simulator.Value() {
+	case "xsim":
+		res = RunXsim(rule, args)
+	case "questa":
+		res = RunQuesta(rule, args)
+	default:
+		log.Fatal(fmt.Sprintf("'run' target not supported for hdl-simulator flag '%s'", Simulator.Value()))
+	}
 
-  return res
+	return res
 }
 
 func (rule Simulation) Test(args []string) string {
-  res := ""
-  switch Simulator.Value() {
-  case "xsim":
-    res = TestXsim(rule, args)
-  case "questa":
-    res = TestQuesta(rule, args)
-  default:
-    log.Fatal(fmt.Sprintf("'test' target not supported for hdl-simulator flag '%s'", Simulator.Value()))
-  }
+	res := ""
+	switch Simulator.Value() {
+	case "xsim":
+		res = TestXsim(rule, args)
+	case "questa":
+		res = TestQuesta(rule, args)
+	default:
+		log.Fatal(fmt.Sprintf("'test' target not supported for hdl-simulator flag '%s'", Simulator.Value()))
+	}
 
-  return res
+	return res
 }
 
 func (rule Simulation) Description() string {
-  // Print the rule name as its needed for parameter selection
-  description := " "
-  first := true
-  for param, _ := range rule.Params {
-    if first {
-      description = description + "Params: "
-      first = false
-    }
-    description = description + param + " "
-  }
+	// Print the rule name as its needed for parameter selection
+	description := " "
+	first := true
+	for param, _ := range rule.Params {
+		if first {
+			description = description + "Params: "
+			first = false
+		}
+		description = description + param + " "
+	}
 
-  if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil {
-    description = description + "TestCases: "
+	if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil {
+		description = description + "TestCases: "
 
-    // Loop through all defined testcases in directory
-    if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
-      for _, item := range items {
-        description = description + item.Name() + " "
-      }
-    } else {
-      log.Fatal(err)
-    }
-  }
+		// Loop through all defined testcases in directory
+		if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
+			for _, item := range items {
+				description = description + item.Name() + " "
+			}
+		} else {
+			log.Fatal(err)
+		}
+	}
 
-  return description
+	return description
 }

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -1,10 +1,10 @@
 package hdl
 
 import (
-  "log"
-  "fmt"
-  "os"
   "dbt-rules/RULES/core"
+  "fmt"
+  "log"
+  "os"
 )
 
 var Simulator = core.StringFlag{
@@ -85,7 +85,7 @@ func (rule Simulation) Description() string {
   // Print the rule name as its needed for parameter selection
   description := " Name: " + rule.Name + " "
   first := true
-  for param, _ := range(rule.Params) {
+  for param, _ := range rule.Params {
     if first {
       description = description + "Params: "
       first = false
@@ -95,7 +95,7 @@ func (rule Simulation) Description() string {
 
   if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil {
     description = description + "TestCases: "
-    
+
     // Loop through all defined testcases in directory
     if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
       for _, item := range items {

--- a/RULES/hdl/utils.go
+++ b/RULES/hdl/utils.go
@@ -7,6 +7,7 @@ import (
 func IsRtl(path string) bool {
   return strings.HasSuffix(path, ".v") ||
     strings.HasSuffix(path, ".sv") ||
+    strings.HasSuffix(path, ".vhdl") ||
     strings.HasSuffix(path, ".vhd")
 }
 

--- a/RULES/hdl/utils.go
+++ b/RULES/hdl/utils.go
@@ -1,38 +1,38 @@
 package hdl
 
 import (
-  "strings"
+	"strings"
 )
 
 func IsRtl(path string) bool {
-  return strings.HasSuffix(path, ".v") ||
-    strings.HasSuffix(path, ".sv") ||
-    strings.HasSuffix(path, ".vhdl") ||
-    strings.HasSuffix(path, ".vhd")
+	return strings.HasSuffix(path, ".v") ||
+		strings.HasSuffix(path, ".sv") ||
+		strings.HasSuffix(path, ".vhdl") ||
+		strings.HasSuffix(path, ".vhd")
 }
 
 func IsVerilog(path string) bool {
-  return strings.HasSuffix(path, ".v") ||
-    strings.HasSuffix(path, ".sv")
+	return strings.HasSuffix(path, ".v") ||
+		strings.HasSuffix(path, ".sv")
 }
 
 func IsVhdl(path string) bool {
-  return strings.HasSuffix(path, ".vhdl") ||
-    strings.HasSuffix(path, ".vhd")
+	return strings.HasSuffix(path, ".vhdl") ||
+		strings.HasSuffix(path, ".vhd")
 }
 
 func IsHeader(path string) bool {
-  return strings.HasSuffix(path, ".svh")
+	return strings.HasSuffix(path, ".svh")
 }
 
 func IsConstraint(path string) bool {
-  return strings.HasSuffix(path, ".xdc")
+	return strings.HasSuffix(path, ".xdc")
 }
 
 func IsXilinxIpCheckpoint(path string) bool {
-  return strings.HasSuffix(path, ".xci")
+	return strings.HasSuffix(path, ".xci")
 }
 
 func IsSimulationArchive(path string) bool {
-  return strings.HasSuffix(path, ".sim.tar.gz")
+	return strings.HasSuffix(path, ".sim.tar.gz")
 }

--- a/RULES/hdl/utils.go
+++ b/RULES/hdl/utils.go
@@ -1,37 +1,37 @@
 package hdl
 
 import (
-	"strings"
+  "strings"
 )
 
 func IsRtl(path string) bool {
-	return strings.HasSuffix(path, ".v") ||
-	       strings.HasSuffix(path, ".sv") ||
-				 strings.HasSuffix(path, ".vhd")
+  return strings.HasSuffix(path, ".v") ||
+    strings.HasSuffix(path, ".sv") ||
+    strings.HasSuffix(path, ".vhd")
 }
 
 func IsVerilog(path string) bool {
-	return strings.HasSuffix(path, ".v") ||
-	       strings.HasSuffix(path, ".sv")
+  return strings.HasSuffix(path, ".v") ||
+    strings.HasSuffix(path, ".sv")
 }
 
 func IsVhdl(path string) bool {
-	return strings.HasSuffix(path, ".vhdl") ||
-				 strings.HasSuffix(path, ".vhd")
+  return strings.HasSuffix(path, ".vhdl") ||
+    strings.HasSuffix(path, ".vhd")
 }
 
 func IsHeader(path string) bool {
-	return strings.HasSuffix(path, ".svh")
+  return strings.HasSuffix(path, ".svh")
 }
 
 func IsConstraint(path string) bool {
-	return strings.HasSuffix(path, ".xdc")
+  return strings.HasSuffix(path, ".xdc")
 }
 
 func IsXilinxIpCheckpoint(path string) bool {
-	return strings.HasSuffix(path, ".xci")
+  return strings.HasSuffix(path, ".xci")
 }
 
 func IsSimulationArchive(path string) bool {
-	return strings.HasSuffix(path, ".sim.tar.gz")
+  return strings.HasSuffix(path, ".sim.tar.gz")
 }

--- a/RULES/hdl/utils.go
+++ b/RULES/hdl/utils.go
@@ -5,7 +5,23 @@ import (
 )
 
 func IsRtl(path string) bool {
-	return strings.HasSuffix(path, ".v") || strings.HasSuffix(path, ".sv") || strings.HasSuffix(path, ".vhd")
+	return strings.HasSuffix(path, ".v") ||
+	       strings.HasSuffix(path, ".sv") ||
+				 strings.HasSuffix(path, ".vhd")
+}
+
+func IsVerilog(path string) bool {
+	return strings.HasSuffix(path, ".v") ||
+	       strings.HasSuffix(path, ".sv")
+}
+
+func IsVhdl(path string) bool {
+	return strings.HasSuffix(path, ".vhdl") ||
+				 strings.HasSuffix(path, ".vhd")
+}
+
+func IsHeader(path string) bool {
+	return strings.HasSuffix(path, ".svh")
 }
 
 func IsConstraint(path string) bool {

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -433,10 +433,9 @@ func simulateXsim(rule Simulation, args []string, gui bool) string {
 			if _, err := fmt.Sscanf(arg, "-params=%s", &param); err != nil {
 				log.Fatal(fmt.Sprintf("-params expects a string argument!"))
 			} else {
-				if _, ok := rule.Params[param]; !ok {
-					log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!", param, rule.Name))
+				if _, ok := rule.Params[param]; ok {
+					params = append(params, param)
 				}
-				params = append(params, param)
 			}
 		}
 	}

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -1,75 +1,492 @@
 package hdl
 
 import (
-	"fmt"
-	"strings"
+  "fmt"
+  "log"
+  "os"
+  "path"
+  "strings"
 
-	"dbt-rules/RULES/core"
-	"dbt-rules/hdl"
+  "dbt-rules/RULES/core"
 )
 
-type XSimScriptParams struct {
-	Name         string
-	PartName     string
-	BoardName    string
-	OutDir       core.Path
-	OutScript    core.Path
-	OutSimScript core.Path
-	IncDir       core.Path
-	Srcs         []core.Path
-	Ips          []core.Path
-	Libs         []string
-	Verbose      bool
+// XvlogFlags enables the user to specify additional flags for the 'vlog' command.
+var XvlogFlags = core.StringFlag{
+  Name: "xvlog-flags",
+  DefaultFn: func() string {
+    return ""
+  },
+}.Register()
+
+// XvhdlFlags enables the user to specify additional flags for the 'vcom' command.
+var XvhdlFlags = core.StringFlag{
+  Name: "xvhdl-flags",
+  DefaultFn: func() string {
+    return ""
+  },
+}.Register()
+
+// XsimFlags enables the user to specify additional flags for the 'vsim' command.
+var XsimFlags = core.StringFlag{
+  Name: "xsim-flags",
+  DefaultFn: func() string {
+    return ""
+  },
+}.Register()
+
+// XelabDebug enables the user to control the accessibility in the compiled design for
+// debugging purposes.
+var XelabDebug = core.StringFlag{
+  Name: "xelab-debug",
+  DefaultFn: func() string {
+    return "typical"
+  },
+}.Register()
+
+// xsim_rules holds a map of all defined rules to prevent defining the same rule
+// multiple times.
+var xsim_rules = make(map[string]bool)
+
+// xsimCompileSrcs compiles a list of sources using the specified context ctx, rule,
+// dependencies and include paths. It returns the resulting dependencies and include paths
+// that result from compiling the source files.
+func xsimCompileSrcs(ctx core.Context, rule Simulation,
+  deps []core.Path, incs []core.Path, srcs []core.Path) ([]core.Path, []core.Path) {
+  for _, src := range srcs {
+    // We handle header files separately from other source files
+    if IsHeader(src.String()) {
+      incs = append(incs, src)
+    } else if IsRtl(src.String()) {
+      // log will point to the log file to be generated when compiling the code
+      log := rule.Path().WithSuffix("/" + src.Relative() + ".log")
+
+      // If we already have a rule for this file, skip it.
+      if xsim_rules[log.String()] {
+        continue
+      }
+
+      // Holds common flags for both 'vlog' and 'vcom' commands
+      cmd := fmt.Sprintf("-work %s --log %s", strings.ToLower(rule.Lib()), log.String())
+
+      // tool will point to the tool to execute (also used for logging below)
+      var tool string
+      if IsVerilog(src.String()) {
+        tool = "xvlog"
+        cmd = cmd + " --sv " + XvlogFlags.Value()
+        cmd = cmd + fmt.Sprintf(" -i %s", core.SourcePath("").String())
+        for _, inc := range incs {
+          cmd = cmd + fmt.Sprintf(" -i %s", path.Dir(inc.Absolute()))
+        }
+      } else if IsVhdl(src.String()) {
+        tool = "xvhdl"
+      }
+
+      // Remove the log file if the command fails to ensure we can recompile it
+      cmd = tool + " " + cmd + " " + src.String() + " > /dev/null" + 
+				" || { cat " + log.String() + "; rm " + log.String() + "; exit 1; }"
+
+      // Add the compilation command as a build step with the log file as the
+      // generated output
+      ctx.AddBuildStep(core.BuildStep{
+        Out:   log,
+        Ins:   append(deps, src),
+        Cmd:   cmd,
+        Descr: fmt.Sprintf("%s: %s", tool, src.Relative()),
+      })
+
+      // Add the log file to the dependencies of the next files
+      deps = append(deps, log)
+
+      // Note down the created rule
+      xsim_rules[log.String()] = true
+    }
+  }
+
+  return deps, incs
 }
 
-type SimulationXsim struct {
-	Name    string
-	Srcs    []core.Path
-	Ips     []Ip
-	Libs    []string
-	Verbose bool
+// xsimCompileIp compiles the IP dependencies and the source files and an IP.
+func xsimCompileIp(ctx core.Context, rule Simulation, ip Ip,
+  deps []core.Path, incs []core.Path) ([]core.Path, []core.Path) {
+  for _, sub_ip := range ip.Ips() {
+    deps, incs = xsimCompileIp(ctx, rule, sub_ip, deps, incs)
+  }
+  deps, incs = xsimCompileSrcs(ctx, rule, deps, incs, ip.Sources())
+
+  return deps, incs
 }
 
-func (rule SimulationXsim) Build(ctx core.Context) {
-	outDir := ctx.Cwd().WithSuffix("/" + rule.Name)
-	outScript := outDir.WithSuffix(".sh")
-	outSimScript := outDir.WithSuffix(".xsim.tcl")
+// xsimCompile compiles the IP dependencies and source files of a simulation rule.
+func xsimCompile(ctx core.Context, rule Simulation) []core.Path {
+  incs := []core.Path{}
+  deps := []core.Path{}
 
-	ins := []core.Path{}
-	srcs := []core.Path{}
-	ips := []core.Path{}
+  for _, ip := range rule.Ips {
+    deps, incs = xsimCompileIp(ctx, rule, ip, deps, incs)
+  }
+  deps, incs = xsimCompileSrcs(ctx, rule, deps, incs, rule.Srcs)
 
-	for _, ip := range FlattenIpGraph(rule.Ips) {
-		for _, src := range ip.Sources() {
-			if IsSimulationArchive(src.String()) {
-				ips = append(ips, src)
-			} else if IsRtl(src.String()) {
-				srcs = append(srcs, src)
-			}
-			ins = append(ins, src)
-		}
+  return deps
+}
+
+// elaborate creates and optimized version of the design optionally including
+// coverage recording functionality. The optimized design unit can then conveniently
+// be simulated using 'xsim'.
+func elaborate(ctx core.Context, rule Simulation, deps []core.Path) {
+  top := "board"
+  if rule.Top != "" {
+    top = rule.Top
+  }
+
+  log_file_suffix := "xelab.log"
+
+  log_files := []core.OutPath{}
+  targets := []string{}
+  params := []string{}
+  if rule.Params != nil {
+    for key, _ := range rule.Params {
+      log_files = append(log_files, rule.Path().WithSuffix("/"+key+"_"+log_file_suffix))
+      targets = append(targets, rule.Name+key)
+      params = append(params, key)
+    }
+  } else {
+    log_files = append(log_files, rule.Path().WithSuffix("/"+log_file_suffix))
+    targets = append(targets, rule.Name)
+    params = append(params, "")
+  }
+
+  for i := range log_files {
+    log_file := log_files[i]
+    target := targets[i]
+    param_set := params[i]
+
+    // Skip if we already have a rule
+    if xsim_rules[log_file.String()] {
+      return
+    }
+
+    cmd := fmt.Sprintf("xelab --timescale 1ns/1ps --debug %s --log %s %s.%s -s %s",
+      XelabDebug.Value(), log_file.String(), strings.ToLower(rule.Lib()), top, target)
+
+    // Set up parameters
+    if param_set != "" {
+      // Check that the parameters exist
+      if params, ok := rule.Params[param_set]; ok {
+        // Add parameters for all generics
+        for param, value := range params {
+          cmd = fmt.Sprintf("%s -generic_top \"%s=%s\"", cmd, param, value)
+        }
+      } else {
+        log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!",
+          params, rule.Name))
+      }
+    }
+
+		cmd = cmd + " > /dev/null || { cat " + log_file.String() + 
+			"; rm " + log_file.String() + "; exit 1; }"
+
+    // Add the rule to run 'vopt'.
+    ctx.AddBuildStep(core.BuildStep{
+      Out:   log_file,
+      Ins:   deps,
+      Cmd:   cmd,
+      Descr: fmt.Sprintf("xelab: %s %s", rule.Lib()+"."+top, target),
+    })
+
+    // Note that we created this rule
+    xsim_rules[log_file.String()] = true
+  }
+}
+
+// BuildXsim will compile and elaborate the source and IPs associated with the given
+// rule.
+func BuildXsim(ctx core.Context, rule Simulation) {
+  // compile the code
+  deps := xsimCompile(ctx, rule)
+
+  // elaborate the code
+  elaborate(ctx, rule, deps)
+}
+
+// xsimVerbosityLevelToFlag takes a verbosity level of none, low, medium or high and
+// converts it to the corresponding DVM_ level.
+func xsimVerbosityLevelToFlag(level string) (string, bool) {
+  var verbosity_flag string
+  var print_output bool
+  switch level {
+  case "none":
+    verbosity_flag = " --testplusarg verbosity=DVM_VERB_NONE"
+    print_output = false
+  case "low":
+    verbosity_flag = " --testplusarg verbosity=DVM_VERB_LOW"
+    print_output = true
+  case "medium":
+    verbosity_flag = " --testplusarg verbosity=DVM_VERB_MED"
+    print_output = true
+  case "high":
+    verbosity_flag = " --testplusarg verbosity=DVM_VERB_HIGH"
+    print_output = true
+  default:
+    log.Fatal(fmt.Sprintf("invalid verbosity flag '%s', only 'low', 'medium',"+
+      " 'high' or 'none' allowed!", level))
+  }
+
+  return verbosity_flag, print_output
+}
+
+// xsimPreamble creates a preamble for the simulation command for the purpose of generating
+// a testcase.
+func xsimPreamble(rule Simulation, testcase string) (string, string) {
+  preamble := ""
+
+  // Create a testcase generation command if necessary
+  if rule.TestCaseGenerator != nil {
+    // No testcase specified, use default
+    if testcase == "" {
+      // If directory of testcases available, pick the first one
+      if rule.TestCasesDir != nil {
+        if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
+          if len(items) == 0 {
+            log.Fatal(fmt.Sprintf("TestCasesDir directory '%s' empty!", rule.TestCasesDir.String()))
+          }
+
+          // Create path to testcase
+          testcase = rule.TestCasesDir.Absolute() + "/" + items[0].Name()
+        }
+      }
+    } else if testcase != "" && rule.TestCasesDir != nil {
+      // Create path to testcase
+      testcase = rule.TestCasesDir.Absolute() + "/" + testcase
+    }
+
+    if testcase == "" {
+      // Create the preamble for testcase generator without any argument
+      preamble = fmt.Sprintf("{ %s . ; }", rule.TestCaseGenerator.String())
+      testcase = "default"
+    } else {
+      // Create the preamble for testcase generator with arguments
+      preamble = fmt.Sprintf("{ %s %s . ; }", rule.TestCaseGenerator.String(), testcase)
+    }
+
+    // Add information to command
+    preamble = fmt.Sprintf("{ echo Generating %s; } && ", testcase) + preamble
+
+    // Trim testcase for use in coverage databaes
+    testcase = strings.TrimSuffix(path.Base(testcase), path.Ext(testcase))
+  }
+
+  return preamble, testcase
+}
+
+// xsimCmd will create a command for starting 'vsim' on the compiled and optimized design with flags
+// set in accordance with what is specified on the command line.
+func xsimCmd(rule Simulation, args []string, gui bool, testcase string, params string) string {
+  // Prefix the vsim command with this
+  cmd_preamble := ""
+
+  // Default log file
+  log_file_suffix := "xsim.log"
+  if testcase != "" {
+    log_file_suffix = testcase + "_" + log_file_suffix
+  }
+  if params != "" {
+    log_file_suffix = params + "_" + log_file_suffix
+  }
+  log_file := rule.Path().WithSuffix("/" + log_file_suffix)
+
+  // Default flag values
+  vsim_flags := " --onfinish quit --log " + log_file.String()
+  seed_flag := " --sv_seed 1"
+  verbosity_flag := " --testplusarg verbosity=DVM_VERB_NONE"
+  mode_flag := ""
+  plusargs_flag := ""
+
+  // Collect do-files here
+  var do_flags []string
+
+  // Turn off output unless verbosity is activated
+  print_output := false
+
+  // Parse additional arguments
+  for _, arg := range args {
+    if strings.HasPrefix(arg, "-seed=") {
+      // Define simulator seed
+      var seed int64
+      if _, err := fmt.Sscanf(arg, "-seed=%d", &seed); err == nil {
+        seed_flag = fmt.Sprintf(" --sv_seed %d", seed)
+      } else {
+        log.Fatal("-seed expects an integer argument!")
+      }
+    } else if strings.HasPrefix(arg, "-verbosity=") {
+      // Define verbosity level
+      var level string
+      if _, err := fmt.Sscanf(arg, "-verbosity=%s", &level); err == nil {
+        verbosity_flag, print_output = xsimVerbosityLevelToFlag(level)
+      } else {
+        log.Fatal("-verbosity expects an argument of 'low', 'medium', 'high' or 'none'!")
+      }
+    } else if strings.HasPrefix(arg, "+") {
+      // All '+' arguments go directly to the simulator
+      plusargs_flag = plusargs_flag + " --testplusarg " + strings.TrimPrefix(arg, "+")
+    }
+  }
+
+  // Create optional command preamble
+  cmd_preamble, testcase = xsimPreamble(rule, testcase)
+
+  cmd_echo := ""
+  if rule.Params != nil && params != "" {
+    // Update coverage database name based on parameters. We cannot merge
+    // different parameter sets, do we have to make a dedicated main database
+    // for this parameter set.
+    cmd_echo = "Testcase " + params
+    
+    // Update with testcase if specified
+    if testcase != "" {
+      cmd_echo = cmd_echo + "/" + testcase + ":"
+      testcase = params + "_" + testcase
+    } else {
+      cmd_echo = cmd_echo + ":"
+      testcase = params
+    }
+  } else {
+    // Update coverage database name with testcase alone, main database stays
+    // the same
+    if testcase != "" {
+      cmd_echo = "Testcase " + testcase + ":"
+    } else {
+      testcase = "default"
+    }
+  }
+
+  cmd_postamble := ""
+  if gui {
+    mode_flag = " --gui"
+    if rule.WaveformInit != nil {
+      do_flags = append(do_flags, rule.WaveformInit.String())
+    }
+  } else {
+		mode_flag = " --runall"
+    cmd_newline := ":"
+    if cmd_echo != "" {
+      cmd_newline = "echo"
+    }
+
+		cmd_postamble = fmt.Sprintf("|| { %s; cat %s; exit 1; }", cmd_newline, log_file.String())
+  }
+
+  vsim_flags = vsim_flags + mode_flag + seed_flag +
+    verbosity_flag + plusargs_flag + XsimFlags.Value()
+
+  for _, do_flag := range do_flags {
+    vsim_flags = vsim_flags + " --tclbatch " + do_flag
+  }
+
+	// Using this part of the command we send the stdout into a black hole to
+	// keep the output clean
+	cmd_devnull := ""
+	if !print_output {
+		cmd_devnull = "> /dev/null"
 	}
-	srcs = append(srcs, rule.Srcs...)
-	ins = append(ins, rule.Srcs...)
+	
+  cmd := fmt.Sprintf("{ echo -n %s && xsim %s %s %s && " + 
+		"{ { ! grep -q FAILURE %s; } && echo PASS; } }", 
+		cmd_echo, vsim_flags, rule.Name+params, cmd_devnull, log_file.String())
+  if cmd_preamble == "" {
+    cmd = cmd + " " + cmd_postamble
+  } else {
+    cmd = "{ { " + cmd_preamble + " } && " + cmd + " } " + cmd_postamble
+  }
 
-	data := XSimScriptParams{
-		PartName:     PartName.Value(),
-		BoardName:    BoardName.Value(),
-		Name:         strings.ToLower(rule.Name),
-		OutDir:       outDir,
-		OutScript:    outScript,
-		OutSimScript: outSimScript,
-		IncDir:       core.SourcePath(""),
-		Srcs:         srcs,
-		Ips:          ips,
-		Libs:         rule.Libs,
-		Verbose:      rule.Verbose,
-	}
+  // Wrap command in another layer of {} to enable chaining
+  cmd = "{ " + cmd + " }"
 
-	ctx.AddBuildStep(core.BuildStep{
-		Outs:   []core.OutPath{outDir, outScript, outSimScript},
-		Ins:    ins,
-		Script: core.CompileTemplateFile(hdl.XSimScriptTmpl.String(), data),
-		Descr:  fmt.Sprintf("Generating XSim simulation %s", outScript.Relative()),
-	})
+  return cmd
+}
+
+// simulateXsim will create a command to start 'vsim' on the compiled design
+// with flags set in accordance with what is specified on the command line. It will
+// optionally build a chain of commands in case the rule has parameters, but
+// no parameters are specified on the command line
+func simulateXsim(rule Simulation, args []string, gui bool) string {
+  // Optional testcase goes here
+  testcases := []string{}
+
+  // Optional parameter set goes here
+  params := []string{}
+
+  // Parse additional arguments
+  for _, arg := range args {
+    if strings.HasPrefix(arg, "-testcase=") && rule.TestCaseGenerator != nil {
+      var testcase string
+      if _, err := fmt.Sscanf(arg, "-testcase=%s", &testcase); err != nil {
+        log.Fatal(fmt.Sprintf("-testcase expects a string argument!"))
+      }
+      testcases = append(testcases, testcase)
+    } else if strings.HasPrefix(arg, "-params=") && rule.Params != nil {
+      var param string
+      if _, err := fmt.Sscanf(arg, "-params=%s", &param); err != nil {
+        log.Fatal(fmt.Sprintf("-params expects a string argument!"))
+      } else {
+        if _, ok := rule.Params[param]; !ok {
+          log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!", param, rule.Name))
+        }
+        params = append(params, param)
+      }
+    }
+  }
+
+  // If no parameters have been specified, simulate them all
+  if rule.Params != nil && len(params) == 0 {
+    for key := range rule.Params {
+      params = append(params, key)
+    }
+  } else if len(params) == 0 {
+    params = append(params, "")
+  }
+
+  // If no testcase has been specified, simulate them all
+  if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil && len(testcases) == 0 {
+    // Loop through all defined testcases in directory
+    if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
+      for _, item := range items {
+        testcases = append(testcases, item.Name())
+      }
+    } else {
+      log.Fatal(err)
+    }
+  } else if len(testcases) == 0 {
+    testcases = append(testcases, "")
+  }
+
+  // Final command
+  cmd := "{ :; }"
+
+  // Loop for all parameter sets
+  for i := range params {
+    // Loop for all test cases
+    for j := range testcases {
+      cmd = cmd + " && " + xsimCmd(rule, args, gui, testcases[j], params[i])
+      // Only one testcase allowed in GUI mode
+      if gui {
+        break
+      }
+    }
+    // Only one parameter set allowed in gui mode
+    if gui {
+      break
+    }
+  }
+
+  return cmd
+}
+
+// Run will build the design and run a simulation in GUI mode.
+func RunXsim(rule Simulation, args []string) string {
+  return simulateXsim(rule, args, true)
+}
+
+// Test will build the design and run a simulation in batch mode.
+func TestXsim(rule Simulation, args []string) string {
+  return simulateXsim(rule, args, false)
 }

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -1,46 +1,46 @@
 package hdl
 
 import (
-  "fmt"
-  "log"
-  "os"
-  "path"
-  "strings"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"strings"
 
-  "dbt-rules/RULES/core"
+	"dbt-rules/RULES/core"
 )
 
 // XvlogFlags enables the user to specify additional flags for the 'vlog' command.
 var XvlogFlags = core.StringFlag{
-  Name: "xvlog-flags",
-  DefaultFn: func() string {
-    return ""
-  },
+	Name: "xvlog-flags",
+	DefaultFn: func() string {
+		return ""
+	},
 }.Register()
 
 // XvhdlFlags enables the user to specify additional flags for the 'vcom' command.
 var XvhdlFlags = core.StringFlag{
-  Name: "xvhdl-flags",
-  DefaultFn: func() string {
-    return ""
-  },
+	Name: "xvhdl-flags",
+	DefaultFn: func() string {
+		return ""
+	},
 }.Register()
 
 // XsimFlags enables the user to specify additional flags for the 'vsim' command.
 var XsimFlags = core.StringFlag{
-  Name: "xsim-flags",
-  DefaultFn: func() string {
-    return ""
-  },
+	Name: "xsim-flags",
+	DefaultFn: func() string {
+		return ""
+	},
 }.Register()
 
 // XelabDebug enables the user to control the accessibility in the compiled design for
 // debugging purposes.
 var XelabDebug = core.StringFlag{
-  Name: "xelab-debug",
-  DefaultFn: func() string {
-    return "typical"
-  },
+	Name: "xelab-debug",
+	DefaultFn: func() string {
+		return "typical"
+	},
 }.Register()
 
 // xsim_rules holds a map of all defined rules to prevent defining the same rule
@@ -51,336 +51,336 @@ var xsim_rules = make(map[string]bool)
 // dependencies and include paths. It returns the resulting dependencies and include paths
 // that result from compiling the source files.
 func xsimCompileSrcs(ctx core.Context, rule Simulation,
-  deps []core.Path, incs []core.Path, srcs []core.Path) ([]core.Path, []core.Path) {
-  for _, src := range srcs {
-    // We handle header files separately from other source files
-    if IsHeader(src.String()) {
-      incs = append(incs, src)
-    } else if IsRtl(src.String()) {
-      // log will point to the log file to be generated when compiling the code
-      log := rule.Path().WithSuffix("/" + src.Relative() + ".log")
+	deps []core.Path, incs []core.Path, srcs []core.Path) ([]core.Path, []core.Path) {
+	for _, src := range srcs {
+		// We handle header files separately from other source files
+		if IsHeader(src.String()) {
+			incs = append(incs, src)
+		} else if IsRtl(src.String()) {
+			// log will point to the log file to be generated when compiling the code
+			log := rule.Path().WithSuffix("/" + src.Relative() + ".log")
 
-      // If we already have a rule for this file, skip it.
-      if xsim_rules[log.String()] {
-        continue
-      }
+			// If we already have a rule for this file, skip it.
+			if xsim_rules[log.String()] {
+				continue
+			}
 
-      // Holds common flags for both 'vlog' and 'vcom' commands
-      cmd := fmt.Sprintf("-work %s --log %s", strings.ToLower(rule.Lib()), log.String())
+			// Holds common flags for both 'vlog' and 'vcom' commands
+			cmd := fmt.Sprintf("-work %s --log %s", strings.ToLower(rule.Lib()), log.String())
 
-      // tool will point to the tool to execute (also used for logging below)
-      var tool string
-      if IsVerilog(src.String()) {
-        tool = "xvlog"
-        cmd = cmd + " --sv " + XvlogFlags.Value()
-        cmd = cmd + fmt.Sprintf(" -i %s", core.SourcePath("").String())
-        for _, inc := range incs {
-          cmd = cmd + fmt.Sprintf(" -i %s", path.Dir(inc.Absolute()))
-        }
-      } else if IsVhdl(src.String()) {
-        tool = "xvhdl"
-      }
+			// tool will point to the tool to execute (also used for logging below)
+			var tool string
+			if IsVerilog(src.String()) {
+				tool = "xvlog"
+				cmd = cmd + " --sv " + XvlogFlags.Value()
+				cmd = cmd + fmt.Sprintf(" -i %s", core.SourcePath("").String())
+				for _, inc := range incs {
+					cmd = cmd + fmt.Sprintf(" -i %s", path.Dir(inc.Absolute()))
+				}
+			} else if IsVhdl(src.String()) {
+				tool = "xvhdl"
+			}
 
-      // Remove the log file if the command fails to ensure we can recompile it
-      cmd = tool + " " + cmd + " " + src.String() + " > /dev/null" + 
+			// Remove the log file if the command fails to ensure we can recompile it
+			cmd = tool + " " + cmd + " " + src.String() + " > /dev/null" +
 				" || { cat " + log.String() + "; rm " + log.String() + "; exit 1; }"
 
-      // Add the compilation command as a build step with the log file as the
-      // generated output
-      ctx.AddBuildStep(core.BuildStep{
-        Out:   log,
-        Ins:   append(deps, src),
-        Cmd:   cmd,
-        Descr: fmt.Sprintf("%s: %s", tool, src.Relative()),
-      })
+			// Add the compilation command as a build step with the log file as the
+			// generated output
+			ctx.AddBuildStep(core.BuildStep{
+				Out:   log,
+				Ins:   append(deps, src),
+				Cmd:   cmd,
+				Descr: fmt.Sprintf("%s: %s", tool, src.Relative()),
+			})
 
-      // Add the log file to the dependencies of the next files
-      deps = append(deps, log)
+			// Add the log file to the dependencies of the next files
+			deps = append(deps, log)
 
-      // Note down the created rule
-      xsim_rules[log.String()] = true
-    }
-  }
+			// Note down the created rule
+			xsim_rules[log.String()] = true
+		}
+	}
 
-  return deps, incs
+	return deps, incs
 }
 
 // xsimCompileIp compiles the IP dependencies and the source files and an IP.
 func xsimCompileIp(ctx core.Context, rule Simulation, ip Ip,
-  deps []core.Path, incs []core.Path) ([]core.Path, []core.Path) {
-  for _, sub_ip := range ip.Ips() {
-    deps, incs = xsimCompileIp(ctx, rule, sub_ip, deps, incs)
-  }
-  deps, incs = xsimCompileSrcs(ctx, rule, deps, incs, ip.Sources())
+	deps []core.Path, incs []core.Path) ([]core.Path, []core.Path) {
+	for _, sub_ip := range ip.Ips() {
+		deps, incs = xsimCompileIp(ctx, rule, sub_ip, deps, incs)
+	}
+	deps, incs = xsimCompileSrcs(ctx, rule, deps, incs, ip.Sources())
 
-  return deps, incs
+	return deps, incs
 }
 
 // xsimCompile compiles the IP dependencies and source files of a simulation rule.
 func xsimCompile(ctx core.Context, rule Simulation) []core.Path {
-  incs := []core.Path{}
-  deps := []core.Path{}
+	incs := []core.Path{}
+	deps := []core.Path{}
 
-  for _, ip := range rule.Ips {
-    deps, incs = xsimCompileIp(ctx, rule, ip, deps, incs)
-  }
-  deps, incs = xsimCompileSrcs(ctx, rule, deps, incs, rule.Srcs)
+	for _, ip := range rule.Ips {
+		deps, incs = xsimCompileIp(ctx, rule, ip, deps, incs)
+	}
+	deps, incs = xsimCompileSrcs(ctx, rule, deps, incs, rule.Srcs)
 
-  return deps
+	return deps
 }
 
 // elaborate creates and optimized version of the design optionally including
 // coverage recording functionality. The optimized design unit can then conveniently
 // be simulated using 'xsim'.
 func elaborate(ctx core.Context, rule Simulation, deps []core.Path) {
-  top := "board"
-  if rule.Top != "" {
-    top = rule.Top
-  }
+	top := "board"
+	if rule.Top != "" {
+		top = rule.Top
+	}
 
-  log_file_suffix := "xelab.log"
+	log_file_suffix := "xelab.log"
 
-  log_files := []core.OutPath{}
-  targets := []string{}
-  params := []string{}
-  if rule.Params != nil {
-    for key, _ := range rule.Params {
-      log_files = append(log_files, rule.Path().WithSuffix("/"+key+"_"+log_file_suffix))
-      targets = append(targets, rule.Name+key)
-      params = append(params, key)
-    }
-  } else {
-    log_files = append(log_files, rule.Path().WithSuffix("/"+log_file_suffix))
-    targets = append(targets, rule.Name)
-    params = append(params, "")
-  }
+	log_files := []core.OutPath{}
+	targets := []string{}
+	params := []string{}
+	if rule.Params != nil {
+		for key, _ := range rule.Params {
+			log_files = append(log_files, rule.Path().WithSuffix("/"+key+"_"+log_file_suffix))
+			targets = append(targets, rule.Name+key)
+			params = append(params, key)
+		}
+	} else {
+		log_files = append(log_files, rule.Path().WithSuffix("/"+log_file_suffix))
+		targets = append(targets, rule.Name)
+		params = append(params, "")
+	}
 
-  for i := range log_files {
-    log_file := log_files[i]
-    target := targets[i]
-    param_set := params[i]
+	for i := range log_files {
+		log_file := log_files[i]
+		target := targets[i]
+		param_set := params[i]
 
-    // Skip if we already have a rule
-    if xsim_rules[log_file.String()] {
-      return
-    }
+		// Skip if we already have a rule
+		if xsim_rules[log_file.String()] {
+			return
+		}
 
-    cmd := fmt.Sprintf("xelab --timescale 1ns/1ps --debug %s --log %s %s.%s -s %s",
-      XelabDebug.Value(), log_file.String(), strings.ToLower(rule.Lib()), top, target)
+		cmd := fmt.Sprintf("xelab --timescale 1ns/1ps --debug %s --log %s %s.%s -s %s",
+			XelabDebug.Value(), log_file.String(), strings.ToLower(rule.Lib()), top, target)
 
-    // Set up parameters
-    if param_set != "" {
-      // Check that the parameters exist
-      if params, ok := rule.Params[param_set]; ok {
-        // Add parameters for all generics
-        for param, value := range params {
-          cmd = fmt.Sprintf("%s -generic_top \"%s=%s\"", cmd, param, value)
-        }
-      } else {
-        log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!",
-          params, rule.Name))
-      }
-    }
+		// Set up parameters
+		if param_set != "" {
+			// Check that the parameters exist
+			if params, ok := rule.Params[param_set]; ok {
+				// Add parameters for all generics
+				for param, value := range params {
+					cmd = fmt.Sprintf("%s -generic_top \"%s=%s\"", cmd, param, value)
+				}
+			} else {
+				log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!",
+					params, rule.Name))
+			}
+		}
 
-		cmd = cmd + " > /dev/null || { cat " + log_file.String() + 
+		cmd = cmd + " > /dev/null || { cat " + log_file.String() +
 			"; rm " + log_file.String() + "; exit 1; }"
 
-    // Add the rule to run 'vopt'.
-    ctx.AddBuildStep(core.BuildStep{
-      Out:   log_file,
-      Ins:   deps,
-      Cmd:   cmd,
-      Descr: fmt.Sprintf("xelab: %s %s", rule.Lib()+"."+top, target),
-    })
+		// Add the rule to run 'vopt'.
+		ctx.AddBuildStep(core.BuildStep{
+			Out:   log_file,
+			Ins:   deps,
+			Cmd:   cmd,
+			Descr: fmt.Sprintf("xelab: %s %s", rule.Lib()+"."+top, target),
+		})
 
-    // Note that we created this rule
-    xsim_rules[log_file.String()] = true
-  }
+		// Note that we created this rule
+		xsim_rules[log_file.String()] = true
+	}
 }
 
 // BuildXsim will compile and elaborate the source and IPs associated with the given
 // rule.
 func BuildXsim(ctx core.Context, rule Simulation) {
-  // compile the code
-  deps := xsimCompile(ctx, rule)
+	// compile the code
+	deps := xsimCompile(ctx, rule)
 
-  // elaborate the code
-  elaborate(ctx, rule, deps)
+	// elaborate the code
+	elaborate(ctx, rule, deps)
 }
 
 // xsimVerbosityLevelToFlag takes a verbosity level of none, low, medium or high and
 // converts it to the corresponding DVM_ level.
 func xsimVerbosityLevelToFlag(level string) (string, bool) {
-  var verbosity_flag string
-  var print_output bool
-  switch level {
-  case "none":
-    verbosity_flag = " --testplusarg verbosity=DVM_VERB_NONE"
-    print_output = false
-  case "low":
-    verbosity_flag = " --testplusarg verbosity=DVM_VERB_LOW"
-    print_output = true
-  case "medium":
-    verbosity_flag = " --testplusarg verbosity=DVM_VERB_MED"
-    print_output = true
-  case "high":
-    verbosity_flag = " --testplusarg verbosity=DVM_VERB_HIGH"
-    print_output = true
-  default:
-    log.Fatal(fmt.Sprintf("invalid verbosity flag '%s', only 'low', 'medium',"+
-      " 'high' or 'none' allowed!", level))
-  }
+	var verbosity_flag string
+	var print_output bool
+	switch level {
+	case "none":
+		verbosity_flag = " --testplusarg verbosity=DVM_VERB_NONE"
+		print_output = false
+	case "low":
+		verbosity_flag = " --testplusarg verbosity=DVM_VERB_LOW"
+		print_output = true
+	case "medium":
+		verbosity_flag = " --testplusarg verbosity=DVM_VERB_MED"
+		print_output = true
+	case "high":
+		verbosity_flag = " --testplusarg verbosity=DVM_VERB_HIGH"
+		print_output = true
+	default:
+		log.Fatal(fmt.Sprintf("invalid verbosity flag '%s', only 'low', 'medium',"+
+			" 'high' or 'none' allowed!", level))
+	}
 
-  return verbosity_flag, print_output
+	return verbosity_flag, print_output
 }
 
 // xsimPreamble creates a preamble for the simulation command for the purpose of generating
 // a testcase.
 func xsimPreamble(rule Simulation, testcase string) (string, string) {
-  preamble := ""
+	preamble := ""
 
-  // Create a testcase generation command if necessary
-  if rule.TestCaseGenerator != nil {
-    // No testcase specified, use default
-    if testcase == "" {
-      // If directory of testcases available, pick the first one
-      if rule.TestCasesDir != nil {
-        if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
-          if len(items) == 0 {
-            log.Fatal(fmt.Sprintf("TestCasesDir directory '%s' empty!", rule.TestCasesDir.String()))
-          }
+	// Create a testcase generation command if necessary
+	if rule.TestCaseGenerator != nil {
+		// No testcase specified, use default
+		if testcase == "" {
+			// If directory of testcases available, pick the first one
+			if rule.TestCasesDir != nil {
+				if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
+					if len(items) == 0 {
+						log.Fatal(fmt.Sprintf("TestCasesDir directory '%s' empty!", rule.TestCasesDir.String()))
+					}
 
-          // Create path to testcase
-          testcase = rule.TestCasesDir.Absolute() + "/" + items[0].Name()
-        }
-      }
-    } else if testcase != "" && rule.TestCasesDir != nil {
-      // Create path to testcase
-      testcase = rule.TestCasesDir.Absolute() + "/" + testcase
-    }
+					// Create path to testcase
+					testcase = rule.TestCasesDir.Absolute() + "/" + items[0].Name()
+				}
+			}
+		} else if testcase != "" && rule.TestCasesDir != nil {
+			// Create path to testcase
+			testcase = rule.TestCasesDir.Absolute() + "/" + testcase
+		}
 
-    if testcase == "" {
-      // Create the preamble for testcase generator without any argument
-      preamble = fmt.Sprintf("{ %s . ; }", rule.TestCaseGenerator.String())
-      testcase = "default"
-    } else {
-      // Create the preamble for testcase generator with arguments
-      preamble = fmt.Sprintf("{ %s %s . ; }", rule.TestCaseGenerator.String(), testcase)
-    }
+		if testcase == "" {
+			// Create the preamble for testcase generator without any argument
+			preamble = fmt.Sprintf("{ %s . ; }", rule.TestCaseGenerator.String())
+			testcase = "default"
+		} else {
+			// Create the preamble for testcase generator with arguments
+			preamble = fmt.Sprintf("{ %s %s . ; }", rule.TestCaseGenerator.String(), testcase)
+		}
 
-    // Add information to command
-    preamble = fmt.Sprintf("{ echo Generating %s; } && ", testcase) + preamble
+		// Add information to command
+		preamble = fmt.Sprintf("{ echo Generating %s; } && ", testcase) + preamble
 
-    // Trim testcase for use in coverage databaes
-    testcase = strings.TrimSuffix(path.Base(testcase), path.Ext(testcase))
-  }
+		// Trim testcase for use in coverage databaes
+		testcase = strings.TrimSuffix(path.Base(testcase), path.Ext(testcase))
+	}
 
-  return preamble, testcase
+	return preamble, testcase
 }
 
 // xsimCmd will create a command for starting 'vsim' on the compiled and optimized design with flags
 // set in accordance with what is specified on the command line.
 func xsimCmd(rule Simulation, args []string, gui bool, testcase string, params string) string {
-  // Prefix the vsim command with this
-  cmd_preamble := ""
+	// Prefix the vsim command with this
+	cmd_preamble := ""
 
-  // Default log file
-  log_file_suffix := "xsim.log"
-  if testcase != "" {
-    log_file_suffix = testcase + "_" + log_file_suffix
-  }
-  if params != "" {
-    log_file_suffix = params + "_" + log_file_suffix
-  }
-  log_file := rule.Path().WithSuffix("/" + log_file_suffix)
+	// Default log file
+	log_file_suffix := "xsim.log"
+	if testcase != "" {
+		log_file_suffix = testcase + "_" + log_file_suffix
+	}
+	if params != "" {
+		log_file_suffix = params + "_" + log_file_suffix
+	}
+	log_file := rule.Path().WithSuffix("/" + log_file_suffix)
 
-  // Default flag values
-  vsim_flags := " --onfinish quit --log " + log_file.String()
-  seed_flag := " --sv_seed 1"
-  verbosity_flag := " --testplusarg verbosity=DVM_VERB_NONE"
-  mode_flag := ""
-  plusargs_flag := ""
+	// Default flag values
+	vsim_flags := " --onfinish quit --log " + log_file.String()
+	seed_flag := " --sv_seed 1"
+	verbosity_flag := " --testplusarg verbosity=DVM_VERB_NONE"
+	mode_flag := ""
+	plusargs_flag := ""
 
-  // Collect do-files here
-  var do_flags []string
+	// Collect do-files here
+	var do_flags []string
 
-  // Turn off output unless verbosity is activated
-  print_output := false
+	// Turn off output unless verbosity is activated
+	print_output := false
 
-  // Parse additional arguments
-  for _, arg := range args {
-    if strings.HasPrefix(arg, "-seed=") {
-      // Define simulator seed
-      var seed int64
-      if _, err := fmt.Sscanf(arg, "-seed=%d", &seed); err == nil {
-        seed_flag = fmt.Sprintf(" --sv_seed %d", seed)
-      } else {
-        log.Fatal("-seed expects an integer argument!")
-      }
-    } else if strings.HasPrefix(arg, "-verbosity=") {
-      // Define verbosity level
-      var level string
-      if _, err := fmt.Sscanf(arg, "-verbosity=%s", &level); err == nil {
-        verbosity_flag, print_output = xsimVerbosityLevelToFlag(level)
-      } else {
-        log.Fatal("-verbosity expects an argument of 'low', 'medium', 'high' or 'none'!")
-      }
-    } else if strings.HasPrefix(arg, "+") {
-      // All '+' arguments go directly to the simulator
-      plusargs_flag = plusargs_flag + " --testplusarg " + strings.TrimPrefix(arg, "+")
-    }
-  }
+	// Parse additional arguments
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-seed=") {
+			// Define simulator seed
+			var seed int64
+			if _, err := fmt.Sscanf(arg, "-seed=%d", &seed); err == nil {
+				seed_flag = fmt.Sprintf(" --sv_seed %d", seed)
+			} else {
+				log.Fatal("-seed expects an integer argument!")
+			}
+		} else if strings.HasPrefix(arg, "-verbosity=") {
+			// Define verbosity level
+			var level string
+			if _, err := fmt.Sscanf(arg, "-verbosity=%s", &level); err == nil {
+				verbosity_flag, print_output = xsimVerbosityLevelToFlag(level)
+			} else {
+				log.Fatal("-verbosity expects an argument of 'low', 'medium', 'high' or 'none'!")
+			}
+		} else if strings.HasPrefix(arg, "+") {
+			// All '+' arguments go directly to the simulator
+			plusargs_flag = plusargs_flag + " --testplusarg " + strings.TrimPrefix(arg, "+")
+		}
+	}
 
-  // Create optional command preamble
-  cmd_preamble, testcase = xsimPreamble(rule, testcase)
+	// Create optional command preamble
+	cmd_preamble, testcase = xsimPreamble(rule, testcase)
 
-  cmd_echo := ""
-  if rule.Params != nil && params != "" {
-    // Update coverage database name based on parameters. We cannot merge
-    // different parameter sets, do we have to make a dedicated main database
-    // for this parameter set.
-    cmd_echo = "Testcase " + params
-    
-    // Update with testcase if specified
-    if testcase != "" {
-      cmd_echo = cmd_echo + "/" + testcase + ":"
-      testcase = params + "_" + testcase
-    } else {
-      cmd_echo = cmd_echo + ":"
-      testcase = params
-    }
-  } else {
-    // Update coverage database name with testcase alone, main database stays
-    // the same
-    if testcase != "" {
-      cmd_echo = "Testcase " + testcase + ":"
-    } else {
-      testcase = "default"
-    }
-  }
+	cmd_echo := ""
+	if rule.Params != nil && params != "" {
+		// Update coverage database name based on parameters. We cannot merge
+		// different parameter sets, do we have to make a dedicated main database
+		// for this parameter set.
+		cmd_echo = "Testcase " + params
 
-  cmd_postamble := ""
-  if gui {
-    mode_flag = " --gui"
-    if rule.WaveformInit != nil {
-      do_flags = append(do_flags, rule.WaveformInit.String())
-    }
-  } else {
+		// Update with testcase if specified
+		if testcase != "" {
+			cmd_echo = cmd_echo + "/" + testcase + ":"
+			testcase = params + "_" + testcase
+		} else {
+			cmd_echo = cmd_echo + ":"
+			testcase = params
+		}
+	} else {
+		// Update coverage database name with testcase alone, main database stays
+		// the same
+		if testcase != "" {
+			cmd_echo = "Testcase " + testcase + ":"
+		} else {
+			testcase = "default"
+		}
+	}
+
+	cmd_postamble := ""
+	if gui {
+		mode_flag = " --gui"
+		if rule.WaveformInit != nil {
+			do_flags = append(do_flags, rule.WaveformInit.String())
+		}
+	} else {
 		mode_flag = " --runall"
-    cmd_newline := ":"
-    if cmd_echo != "" {
-      cmd_newline = "echo"
-    }
+		cmd_newline := ":"
+		if cmd_echo != "" {
+			cmd_newline = "echo"
+		}
 
 		cmd_postamble = fmt.Sprintf("|| { %s; cat %s; exit 1; }", cmd_newline, log_file.String())
-  }
+	}
 
-  vsim_flags = vsim_flags + mode_flag + seed_flag +
-    verbosity_flag + plusargs_flag + XsimFlags.Value()
+	vsim_flags = vsim_flags + mode_flag + seed_flag +
+		verbosity_flag + plusargs_flag + XsimFlags.Value()
 
-  for _, do_flag := range do_flags {
-    vsim_flags = vsim_flags + " --tclbatch " + do_flag
-  }
+	for _, do_flag := range do_flags {
+		vsim_flags = vsim_flags + " --tclbatch " + do_flag
+	}
 
 	// Using this part of the command we send the stdout into a black hole to
 	// keep the output clean
@@ -388,20 +388,20 @@ func xsimCmd(rule Simulation, args []string, gui bool, testcase string, params s
 	if !print_output {
 		cmd_devnull = "> /dev/null"
 	}
-	
-  cmd := fmt.Sprintf("{ echo -n %s && xsim %s %s %s && " + 
-		"{ { ! grep -q FAILURE %s; } && echo PASS; } }", 
+
+	cmd := fmt.Sprintf("{ echo -n %s && xsim %s %s %s && "+
+		"{ { ! grep -q FAILURE %s; } && echo PASS; } }",
 		cmd_echo, vsim_flags, rule.Name+params, cmd_devnull, log_file.String())
-  if cmd_preamble == "" {
-    cmd = cmd + " " + cmd_postamble
-  } else {
-    cmd = "{ { " + cmd_preamble + " } && " + cmd + " } " + cmd_postamble
-  }
+	if cmd_preamble == "" {
+		cmd = cmd + " " + cmd_postamble
+	} else {
+		cmd = "{ { " + cmd_preamble + " } && " + cmd + " } " + cmd_postamble
+	}
 
-  // Wrap command in another layer of {} to enable chaining
-  cmd = "{ " + cmd + " }"
+	// Wrap command in another layer of {} to enable chaining
+	cmd = "{ " + cmd + " }"
 
-  return cmd
+	return cmd
 }
 
 // simulateXsim will create a command to start 'vsim' on the compiled design
@@ -409,84 +409,84 @@ func xsimCmd(rule Simulation, args []string, gui bool, testcase string, params s
 // optionally build a chain of commands in case the rule has parameters, but
 // no parameters are specified on the command line
 func simulateXsim(rule Simulation, args []string, gui bool) string {
-  // Optional testcase goes here
-  testcases := []string{}
+	// Optional testcase goes here
+	testcases := []string{}
 
-  // Optional parameter set goes here
-  params := []string{}
+	// Optional parameter set goes here
+	params := []string{}
 
-  // Parse additional arguments
-  for _, arg := range args {
-    if strings.HasPrefix(arg, "-testcase=") && rule.TestCaseGenerator != nil {
-      var testcase string
-      if _, err := fmt.Sscanf(arg, "-testcase=%s", &testcase); err != nil {
-        log.Fatal(fmt.Sprintf("-testcase expects a string argument!"))
-      }
-      testcases = append(testcases, testcase)
-    } else if strings.HasPrefix(arg, "-params=") && rule.Params != nil {
-      var param string
-      if _, err := fmt.Sscanf(arg, "-params=%s", &param); err != nil {
-        log.Fatal(fmt.Sprintf("-params expects a string argument!"))
-      } else {
-        if _, ok := rule.Params[param]; !ok {
-          log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!", param, rule.Name))
-        }
-        params = append(params, param)
-      }
-    }
-  }
+	// Parse additional arguments
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-testcase=") && rule.TestCaseGenerator != nil {
+			var testcase string
+			if _, err := fmt.Sscanf(arg, "-testcase=%s", &testcase); err != nil {
+				log.Fatal(fmt.Sprintf("-testcase expects a string argument!"))
+			}
+			testcases = append(testcases, testcase)
+		} else if strings.HasPrefix(arg, "-params=") && rule.Params != nil {
+			var param string
+			if _, err := fmt.Sscanf(arg, "-params=%s", &param); err != nil {
+				log.Fatal(fmt.Sprintf("-params expects a string argument!"))
+			} else {
+				if _, ok := rule.Params[param]; !ok {
+					log.Fatal(fmt.Sprintf("parameter set '%s' not defined for Simulation target '%s'!", param, rule.Name))
+				}
+				params = append(params, param)
+			}
+		}
+	}
 
-  // If no parameters have been specified, simulate them all
-  if rule.Params != nil && len(params) == 0 {
-    for key := range rule.Params {
-      params = append(params, key)
-    }
-  } else if len(params) == 0 {
-    params = append(params, "")
-  }
+	// If no parameters have been specified, simulate them all
+	if rule.Params != nil && len(params) == 0 {
+		for key := range rule.Params {
+			params = append(params, key)
+		}
+	} else if len(params) == 0 {
+		params = append(params, "")
+	}
 
-  // If no testcase has been specified, simulate them all
-  if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil && len(testcases) == 0 {
-    // Loop through all defined testcases in directory
-    if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
-      for _, item := range items {
-        testcases = append(testcases, item.Name())
-      }
-    } else {
-      log.Fatal(err)
-    }
-  } else if len(testcases) == 0 {
-    testcases = append(testcases, "")
-  }
+	// If no testcase has been specified, simulate them all
+	if rule.TestCaseGenerator != nil && rule.TestCasesDir != nil && len(testcases) == 0 {
+		// Loop through all defined testcases in directory
+		if items, err := os.ReadDir(rule.TestCasesDir.String()); err == nil {
+			for _, item := range items {
+				testcases = append(testcases, item.Name())
+			}
+		} else {
+			log.Fatal(err)
+		}
+	} else if len(testcases) == 0 {
+		testcases = append(testcases, "")
+	}
 
-  // Final command
-  cmd := "{ :; }"
+	// Final command
+	cmd := "{ :; }"
 
-  // Loop for all parameter sets
-  for i := range params {
-    // Loop for all test cases
-    for j := range testcases {
-      cmd = cmd + " && " + xsimCmd(rule, args, gui, testcases[j], params[i])
-      // Only one testcase allowed in GUI mode
-      if gui {
-        break
-      }
-    }
-    // Only one parameter set allowed in gui mode
-    if gui {
-      break
-    }
-  }
+	// Loop for all parameter sets
+	for i := range params {
+		// Loop for all test cases
+		for j := range testcases {
+			cmd = cmd + " && " + xsimCmd(rule, args, gui, testcases[j], params[i])
+			// Only one testcase allowed in GUI mode
+			if gui {
+				break
+			}
+		}
+		// Only one parameter set allowed in gui mode
+		if gui {
+			break
+		}
+	}
 
-  return cmd
+	return cmd
 }
 
 // Run will build the design and run a simulation in GUI mode.
 func RunXsim(rule Simulation, args []string) string {
-  return simulateXsim(rule, args, true)
+	return simulateXsim(rule, args, true)
 }
 
 // Test will build the design and run a simulation in batch mode.
 func TestXsim(rule Simulation, args []string) string {
-  return simulateXsim(rule, args, false)
+	return simulateXsim(rule, args, false)
 }

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -12,35 +12,40 @@ import (
 
 // XvlogFlags enables the user to specify additional flags for the 'vlog' command.
 var XvlogFlags = core.StringFlag{
-	Name: "xvlog-flags",
+	Name: "xsim-xvlog-flags",
 	DefaultFn: func() string {
 		return ""
 	},
+	Description: "Extra flags for the xvlog command",
 }.Register()
 
 // XvhdlFlags enables the user to specify additional flags for the 'vcom' command.
 var XvhdlFlags = core.StringFlag{
-	Name: "xvhdl-flags",
+	Name: "xsim-xvhdl-flags",
 	DefaultFn: func() string {
 		return ""
 	},
+	Description: "Extra flags for the xvhdl command",
 }.Register()
 
 // XsimFlags enables the user to specify additional flags for the 'vsim' command.
 var XsimFlags = core.StringFlag{
-	Name: "xsim-flags",
+	Name: "xsim-xsim-flags",
 	DefaultFn: func() string {
 		return ""
 	},
+	Description: "Extra flags for the xsim command",
 }.Register()
 
 // XelabDebug enables the user to control the accessibility in the compiled design for
 // debugging purposes.
 var XelabDebug = core.StringFlag{
-	Name: "xelab-debug",
+	Name: "xsim-xelab-debug",
 	DefaultFn: func() string {
 		return "typical"
 	},
+	Description:   "Extra debug flags for the xelab command",
+	AllowedValues: []string{"line", "wave", "drivers", "readers", "xlibs", "all", "typical", "subprogram", "off"},
 }.Register()
 
 // xsim_rules holds a map of all defined rules to prevent defining the same rule

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -190,7 +190,12 @@ func elaborate(ctx core.Context, rule Simulation, deps []core.Path) {
 		cmd = cmd + " > /dev/null || { cat " + log_file.String() +
 			"; rm " + log_file.String() + "; exit 1; }"
 
-		// Add the rule to run 'vopt'.
+		// Hack: Add testcase generator as an optional dependency
+		if rule.TestCaseGenerator != nil {
+			deps = append(deps, rule.TestCaseGenerator)
+		}
+
+		// Add the rule to run 'xelab'.
 		ctx.AddBuildStep(core.BuildStep{
 			Out:   log_file,
 			Ins:   deps,


### PR DESCRIPTION
# Overview
The purpose of the following PR is to provide an improved HDL simulation flow. The main changes are:
- Adds support for `dbt run` and `dbt test` in addition to `dbt build`
- Now, `dbt run` is used for starting the simulation in UI mode
- And `dbt test` is used for running unit tests (i.e. batch mode)
- New flags are available including the ability to define the parameters of the top-level design from the `Simulation` target.
- Coverage information can also be activated.

# How to use

Run the usual `dbt build` command to see a list of available build targets. Each target now has additional information as shown below:

```
$ dbt build
...
//exp-compute/vta/hw/dta_v1/sim/dta_core/DtaCoreSimulation  //exp-compute/vta/hw/dta_v1/sim/dta_core/DtaCoreSimulation ( Name: DtaCore TestCases: add-10x10-16ch.json add-2x2-16ch.json conv-10x10-16ch.json conv-1x1-16ch.json conv-3x3-16ch.json conv-3x3-1ch.json conv-big.json maxpool-10x10-16ch.json maxpool-3x3-16ch.json relu-2x2-16ch.json resize-10x10-16ch.json resize-2x2-16ch.json )
...
//exp-compute/vta/hw/dta_v1/sim/common/axi/axi_register_bank/Simulation  //exp-compute/vta/hw/dta_v1/sim/common/axi/axi_register_bank/Simulation ( Name: AxiRegisterBankSimulation Params: default AxiDataWidth64 AxiAddrWidth32 DefaultMask RegisterCount1 RegisterCount16 )
...
```
The additional information will be discussed in more detail below.

## Test
Use the `dbt test` command to execute unit tests. The command will execute the simulator in batch mode and create code coverage if selected.

## Run
Use the `dbt run` command to execute tests in GUI mode. The simulator will open the UI and read in an optional waveform configuration file. Note that it will _not_ automatically store code coverage data at the end of the simulation.

## Coverage
Code coverage may be generated using the `dbt test` with the flag `questa-coverage=true`. Code coverage will produce an HTML report of the entire design in the `BUILD/OUTPUT-XXX` folder as well as a coverage database in UCDB format. The coverage database can be viewed using the `vsim -viewcov <database>` command.

Note that the tool will create a single coverage database for every simulation target, which merges the results of all simulation runs from e.g. multiple testcases and/or multiple parameter sets.

## Params
The `Params` enables different named parameter sets to be defined. The option is useful for modules with parameters where a single top-level testbench may be used to verify different configurations of the modules. To add a parameter set use the `Params` field of the `hdl.Simulation` target like this:

```
var Simulation = hdl.Simulation{
	Name:   "AxiRegisterBankSimulation",
	Srcs:   ins("tb.sv"),
	Ips:    Ips,
	Top:    "tb",
	Params: hdl.ParamMap{
		"default": {}, 
		"AxiDataWidth64": {"AxiDataWidth": "64"},
		"AxiAddrWidth32": {"AxiAddrWidth": "32"},
		"DefaultMask":    {
			"DefaultMask": "1",
			"DefaultReadOnly": "1",
		},
		"RegisterCount1":  {"RegisterCount": "1"},
		"RegisterCount16": {"RegisterCount": "16"},
	},
	WaveformInit: in("wave.do"),
}
```
The `Params` field is a map with strings as keys. The key is the name of the parameter set. The content of each entry should themselves be a map from strings to strings. The key is the parameter name and the value is the parameter value. The parameters of a parameter set will be applied during the `vopt` step using the `-G` option, e.g. `-G AxiDataWidth=64`.

Parameters can be selected using the `-params` flag. For example, to select `RegisterCount16` as the parameter set one should execute e.g.
```
$ dbt test compute/vta/hw/dta_v1/sim/common/axi/axi_register_bank/Simulation : -params=RegisterCount16
```
Note that all parameter sets are always compiled, so make sure that they are syntactically correct. You can select multiple parameter sets to execute by specifying them as a comma separated list.

## TestCases
Some testbenches require the use of an external test generator script for creating input data and expected output. The generator can be entered using the `TestCaseGenerator` and `TestCasesDir` fields of the `hdl.Simulator` target, like this:

```
var DtaCoreSimulation = hdl.Simulation{
	Name: "DtaCore",
	Srcs: ins(
		"tb.sv",
	),
	Ips: []hdl.Ip{
		util.Logger,
		interfaces.Stream,
		common.DtaPackage,
		rtl.Dta,
		fetch.FetchTest,
		issue.IssueTest,
		dma.DmaTest,
		execute.ExecuteTest,
		axi_register_bank.AxiRegBankTestPackage,
	},
	TestCaseGenerator: in("../../../../../../../DEPS/exp-dta-compiler/testgen"),
	TestCasesDir:      sim.TestCases,
}
```
The `TestCasesDir` is optional. However, if defined, every file in the directory will be listed as an optional testcase. By default, if `TestCaseGenerator` is defined, the generator will always be executed. If no testcase is specifically selected on the command line and `TestCasesDir` is defined, then the first file in the directory will be used as the default testcase.

To execute a specific testcase do
```
$ dbt test //exp-compute/vta/hw/dta_v1/sim/dta_core/DtaCoreSimulation : -testcases=maxpool-10x10-16ch.json
```
Multiple testcases can be specified using a comma separated list, e.g. `-testcases=default.json,maxpool-10x10-16ch.json'.
