### PR TITLE
Adding parsing of source files to discover testcases

### DIFF
--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -84,6 +84,7 @@ func xsimCompileSrcs(ctx core.Context, rule Simulation,
 				}
 			} else if IsVhdl(src.String()) {
 				tool = "xvhdl"
+				cmd = cmd + " " + XvhdlFlags.Value()
 			}
 
 			// Remove the log file if the command fails to ensure we can recompile it


### PR DESCRIPTION
The purpose of this PR is to add an option to enable DBT to scan the source files to discover testcases that can be selected at runtime. Essentially, the tool will look for SystemVerilog constructs of the form `` `TEST_CASE("<name>")`` to indicate the existence of a testcase with the name `<name>`.