### PR TITLE
Adjust test generator code for use with compiler v2

### DIFF
--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -50,16 +50,17 @@ var ShowTestCasesFile = core.BoolFlag{
 type ParamMap map[string]map[string]string
 
 type Simulation struct {
-	Name              string
-	Srcs              []core.Path
-	Ips               []Ip
-	Libs              []string
-	Params            ParamMap
-	Top               string
-	Dut               string
-	TestCaseGenerator core.Path
-	TestCasesDir      core.Path
-	WaveformInit      core.Path
+	Name                   string
+	Srcs                   []core.Path
+	Ips                    []Ip
+	Libs                   []string
+	Params                 ParamMap
+	Top                    string
+	Dut                    string
+	TestCaseGenerator      core.Path
+	TestCaseGeneratorFlags string
+	TestCasesDir           core.Path
+	WaveformInit           core.Path
 }
 
 // Lib returns the standard library name defined for this rule.
@@ -217,9 +218,16 @@ func Preamble(rule Simulation, testcase string) (string, string) {
 			if _, err := os.Stat(testcase); errors.Is(err, os.ErrNotExist) {
 				log.Fatal(fmt.Sprintf("Testcase '%s' does not exist!", testcase))
 			}
-			
+			testCaseGeneratorFlags := rule.TestCaseGeneratorFlags
+			// Check format of the testcase file
+			if strings.HasSuffix(testcase, ".json") {
+				testCaseGeneratorFlags += " -testcase"
+			} else if strings.HasSuffix(testcase, ".onnx") {
+				testCaseGeneratorFlags += " -onnx"
+			}
+
 			// Create the preamble for testcase generator with arguments
-			preamble = fmt.Sprintf("{ %s %s . ; }", rule.TestCaseGenerator.String(), testcase)
+			preamble = fmt.Sprintf("{ %s %s %s -out . ; }", rule.TestCaseGenerator.String(), testCaseGeneratorFlags, testcase)
 		}
 
 		// Add information to command


### PR DESCRIPTION
The interface of the DTA test generator is changing with the update to
compiler version 2. Particularly there are now flags to generate basic
operator tests from json files or more complex tests from onnx files
Additionally the output format can be switched between hex and binary
files.