### PR TITLE
Remove constraints on output paths from default out-of-context synthesis

### DIFF
--- a/hdl/XilinxOutOfContextConstraints.tmpl
+++ b/hdl/XilinxOutOfContextConstraints.tmpl
@@ -6,6 +6,11 @@ set_property HD.CLK_SRC BUFGCTRL_X0Y16 [get_ports {{ .ClockSignal }}]
 # Set input and output delays to this module to 40% of clock period.
 set IO_DELAY [expr 0.4 * $CLOCK_PERIOD]
 
-# set_max_delay constrains the maximum delay *of the path*, not the assumed delay of the signal at input/outputs.
-set_max_delay -from [get_ports -filter { NAME =~ "*" && DIRECTION == "IN" && NAME != {{ .ClockSignal }} }] [ expr $CLOCK_PERIOD - $IO_DELAY ]
-set_max_delay -to [get_ports -filter { NAME =~ "*" && DIRECTION == "OUT" } ] [ expr $CLOCK_PERIOD - $IO_DELAY ]
+# Set_max_delay constrains the maximum delay *of the path*,
+# not the assumed delay of the signal at inputs
+set_max_delay                                                                                        \
+        -from [get_ports -filter { NAME =~ "*" && DIRECTION == "IN" && NAME != {{ .ClockSignal }} }] \
+	[expr $CLOCK_PERIOD - $IO_DELAY]
+
+# Disregard output paths
+set_false_path -to [get_ports *_o]


### PR DESCRIPTION
Out of context synthesis results are not reliable 
relying on arbitrarily defined constraints on output paths.
This removes all output paths from consideration by default.