### PR TITLE
Enable file-specific flags

### DIFF
--- a/RULES/hdl/hdl.go
+++ b/RULES/hdl/hdl.go
@@ -18,10 +18,13 @@ var PartName = core.StringFlag{
 	},
 }.Register()
 
+type FlagMap map[string]string
+
 type Ip interface {
 	Sources() []core.Path
 	Data() []core.Path
 	Ips() []Ip
+	Flags() FlagMap
 }
 
 type Library struct {
@@ -29,6 +32,7 @@ type Library struct {
 	Srcs      []core.Path
 	DataFiles []core.Path
 	IpDeps    []Ip
+	ToolFlags FlagMap
 }
 
 func (lib Library) Sources() []core.Path {
@@ -41,4 +45,8 @@ func (lib Library) Data() []core.Path {
 
 func (lib Library) Ips() []Ip {
 	return lib.IpDeps
+}
+
+func (lib Library) Flags() FlagMap {
+	return lib.ToolFlags
 }

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -321,6 +321,11 @@ func optimize(ctx core.Context, rule Simulation, deps []core.Path) {
       Descr: fmt.Sprintf("vopt: %s %s", rule.Lib()+"."+top, target),
     })
 
+		// Note that we created this rule
+		rules[log_file.String()] = true
+	}
+}
+
 // Create a simulation script
 func doFile(ctx core.Context, rule Simulation) {
 	// Do-file script

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -145,80 +145,90 @@ if {!$gui} {
 // dependencies and include paths. It returns the resulting dependencies and include paths
 // that result from compiling the source files.
 func compileSrcs(ctx core.Context, rule Simulation,
-	deps []core.Path, incs []core.Path, srcs []core.Path) ([]core.Path, []core.Path) {
-	for _, src := range srcs {
-		if IsRtl(src.String()) {
-			// log will point to the log file to be generated when compiling the code
-			log := rule.Path().WithSuffix("/" + src.Relative() + ".log")
+  deps []core.Path, incs []core.Path, srcs []core.Path, flags FlagMap) ([]core.Path, []core.Path) {
+  for _, src := range srcs {
+    if IsRtl(src.String()) {
+      // log will point to the log file to be generated when compiling the code
+      log := rule.Path().WithSuffix("/" + src.Relative() + ".log")
 
-			// If we already have a rule for this file, skip it.
-			if rules[log.String()] {
-				continue
-			}
+      // If we already have a rule for this file, skip it.
+      if rules[log.String()] {
+        continue
+      }
 
-			// Holds common flags for both 'vlog' and 'vcom' commands
-			cmd := fmt.Sprintf("%s +acc=%s -work %s -l %s", common_flags, Access.Value(), rule.Lib(), log.String())
+      // Holds common flags for both 'vlog' and 'vcom' commands
+      cmd := fmt.Sprintf("%s +acc=%s -work %s -l %s", common_flags, Access.Value(), rule.Lib(), log.String())
 
-			// tool will point to the tool to execute (also used for logging below)
-			var tool string
-			if IsVerilog(src.String()) {
-				tool = "vlog"
-				cmd = cmd + " " + VlogFlags.Value()
-				cmd = cmd + " -suppress 2583 -svinputport=net"
-				cmd = cmd + fmt.Sprintf(" +incdir+%s", core.SourcePath("").String())
-				for _, inc := range incs {
-					cmd = cmd + fmt.Sprintf(" +incdir+%s", path.Dir(inc.Absolute()))
+      // tool will point to the tool to execute (also used for logging below)
+      var tool string
+      if IsVerilog(src.String()) {
+        tool = "vlog"
+        cmd = cmd + " " + VlogFlags.Value()
+        cmd = cmd + " -suppress 2583 -svinputport=net"
+        cmd = cmd + fmt.Sprintf(" +incdir+%s", core.SourcePath("").String())
+        for _, inc := range incs {
+          cmd = cmd + fmt.Sprintf(" +incdir+%s", path.Dir(inc.Absolute()))
+        }
+				if flags != nil {
+					if vlog_flags, ok := flags["vlog"]; ok {
+						cmd = cmd + " " + vlog_flags
+					}
 				}
-			} else if IsVhdl(src.String()) {
-				tool = "vcom"
-				cmd = cmd + " " + VcomFlags.Value()
-			}
+      } else if IsVhdl(src.String()) {
+        tool = "vcom"
+        cmd = cmd + " " + VcomFlags.Value()
+				if flags != nil {
+					if vcom_flags, ok := flags["vcom"]; ok {
+						cmd = cmd + " " + vcom_flags
+					}
+				}
+      }
 
-			if Lint.Value() {
-				cmd = cmd + " -lint"
-			}
+      if Lint.Value() {
+        cmd = cmd + " -lint"
+      }
 
-			// Create plain compilation command
-			cmd = tool + " " + cmd + " " + src.String()
+      // Create plain compilation command
+      cmd = tool + " " + cmd + " " + src.String()
 
-			// Remove the log file if the command fails to ensure we can recompile it
-			cmd = cmd + " || { rm " + log.String() + " && exit 1; }"
+      // Remove the log file if the command fails to ensure we can recompile it
+      cmd = cmd + " || { rm " + log.String() + " && exit 1; }"
 
-			// Add the compilation command as a build step with the log file as the
-			// generated output
-			ctx.AddBuildStep(core.BuildStep{
-				Out:   log,
-				Ins:   append(deps, src),
-				Cmd:   cmd,
-				Descr: fmt.Sprintf("%s: %s", tool, src.Relative()),
-			})
+      // Add the compilation command as a build step with the log file as the
+      // generated output
+      ctx.AddBuildStep(core.BuildStep{
+        Out:   log,
+        Ins:   append(deps, src),
+        Cmd:   cmd,
+        Descr: fmt.Sprintf("%s: %s", tool, src.Relative()),
+      })
 
-			// Add the log file to the dependencies of the next files
-			deps = append(deps, log)
+      // Add the log file to the dependencies of the next files
+      deps = append(deps, log)
 
-			// Note down the created rule
-			rules[log.String()] = true
-		} else {
-			// We handle header files separately from other source files
-			if IsHeader(src.String()) {
-				incs = append(incs, src)
-			}
+      // Note down the created rule
+      rules[log.String()] = true
+    } else {
+      // We handle header files separately from other source files
+      if IsHeader(src.String()) {
+        incs = append(incs, src)
+      }
 
-			// Just add the file to the dependencies of the next one (including header files)
-			deps = append(deps, src)
-		}
-	}
+      // Just add the file to the dependencies of the next one (including header files)
+      deps = append(deps, src)
+    }
+  }
 
-	return deps, incs
+  return deps, incs
 }
 
 // compileIp compiles the IP dependencies and the source files and an IP.
 func compileIp(ctx core.Context, rule Simulation, ip Ip,
-	deps []core.Path, incs []core.Path) ([]core.Path, []core.Path) {
-	for _, sub_ip := range ip.Ips() {
-		deps, incs = compileIp(ctx, rule, sub_ip, deps, incs)
-	}
-	deps, incs = compileSrcs(ctx, rule, deps, incs, ip.Sources())
+  deps []core.Path, incs []core.Path) ([]core.Path, []core.Path) {
+  for _, sub_ip := range ip.Ips() {
+    deps, incs = compileIp(ctx, rule, sub_ip, deps, incs)
+  }
+  deps, incs = compileSrcs(ctx, rule, deps, incs, ip.Sources(), ip.Flags())
 
 	return deps, incs
 }
@@ -228,10 +238,10 @@ func compile(ctx core.Context, rule Simulation) []core.Path {
 	incs := []core.Path{}
 	deps := []core.Path{}
 
-	for _, ip := range rule.Ips {
-		deps, incs = compileIp(ctx, rule, ip, deps, incs)
-	}
-	deps, incs = compileSrcs(ctx, rule, deps, incs, rule.Srcs)
+  for _, ip := range rule.Ips {
+    deps, incs = compileIp(ctx, rule, ip, deps, incs)
+  }
+  deps, incs = compileSrcs(ctx, rule, deps, incs, rule.Srcs, rule.ToolFlags)
 
 	return deps
 }

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -55,6 +55,7 @@ type Simulation struct {
 	Ips                    []Ip
 	Libs                   []string
 	Params                 ParamMap
+	ToolFlags              FlagMap
 	Top                    string
 	Dut                    string
 	TestCaseGenerator      core.Path


### PR DESCRIPTION
Updated Library and Simulation targets with a ToolFlags option to enable file-specific flags to be set for the different tools.

It can be used like this:
```go
var AxiLiteProtocolChecker = hdl.Library{
	Srcs: ins(
		"Axi4LitePC_message_defs.vh",
		"Axi4LitePC_message_undefs.vh",
		"Axi4LitePC.sv",
	),
	IpDeps: []hdl.Ip{
		AxiProtocolChecker,
	},
	ToolFlags: hdl.FlagMap{
		"vlog": "-suppress 13361",
	},
}
```
to suppress e.g. specific warnings from specific groups of files.

The `ToolFlags` entries are currently only interpreted by the `Questa` simulator target, but it can easily be added to other targets as well. 
