### PR TITLE
Add waveform init script to `reload` command

### DIFF
--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -112,6 +112,10 @@ const do_file_template = `
 proc reload {} {
 	global target
 	vsim -work {{ .Lib }} $target
+	{{ if .WaveformInit }}
+		source {{ .WaveformInit }}
+	{{ end }}
+
 }
 
 {{ if .WaveformInit }}


### PR DESCRIPTION
 Upon reloading a GUI mode simulation, populate the waveform window with default selection of signals.