### PR TITLE
Updated access flags

### DIFF
--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -51,7 +51,7 @@ var Lint = core.BoolFlag{
 var Access = core.StringFlag{
 	Name: "questa-access",
 	DefaultFn: func() string {
-		return "rna"
+		return "debug"
 	},
 	Description: "Control access to simulation objects for debugging purposes",
 }.Register()
@@ -156,8 +156,7 @@ func compileSrcs(ctx core.Context, rule Simulation,
 				continue
 			}
 
-			// Holds common flags for both 'vlog' and 'vcom' commands
-			cmd := fmt.Sprintf("%s +acc=%s -work %s -l %s", common_flags, Access.Value(), rule.Lib(), log.String())
+			cmd := fmt.Sprintf("%s -work %s -l %s", common_flags, rule.Lib(), log.String())
 
 			// tool will point to the tool to execute (also used for logging below)
 			var tool string
@@ -287,8 +286,16 @@ func optimize(ctx core.Context, rule Simulation, deps []core.Path) {
 			return
 		}
 
-		cmd := fmt.Sprintf("vopt %s %s +acc=%s -l %s -work %s %s -o %s",
-			common_flags, cover_flag, Access.Value(),
+		// Generate access flag
+		access_flag := ""
+		if Access.Value() == "debug" {
+			access_flag = "+acc"
+		} else if Access.Value() != "" {
+			access_flag = fmt.Sprintf("+acc=%s", Access.Value())
+		}
+
+		cmd := fmt.Sprintf("vopt %s %s %s -l %s -work %s %s -o %s",
+			common_flags, cover_flag, access_flag,
 			log_file.String(), rule.Lib(), top, target)
 
 		// Set up parameters

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -57,6 +57,7 @@ type Simulation struct {
 	Params                 ParamMap
 	ToolFlags              FlagMap
 	Top                    string
+	Tops                   []string
 	Dut                    string
 	TestCaseGenerator      core.Path
 	TestCaseGeneratorFlags string


### PR DESCRIPTION
The purpose of this PR is to enable access to be turned off for regression simulations. The access flags can now take on the following values:
- `debug` (default) mapped to `vopt +acc` to enable waveform dumbing
- empty mapped to `vopt` (i.e no `+acc` flat) to disable visibility in the design and speed up simulation
- other value mapped to `vopt +acc=<value>` for user-defined values.

In addition, the PR also improves support for Xilinx IP libraries as needed for simulations directly using Xilinx IP. First, the `Simulation` target has been extended with an additional member `Tops` that can be used instead of `Top` to specify multiple top-level units for simulation. This is needed to simulate the `glbl` block of Xilinx together with the top-level of the design for gate-level simulation.

Finally, the `Libs` member of the `Simulation` target can now be set to a list of libraries to read in. For gate-level simulations, this would be set to e.g. `unisims_ver`, but that really depends on the design being simulated.