### PR TITLE
Removing xilinx build target from rules

### DIFF
--- a/xilinx/BUILD.go
+++ b/xilinx/BUILD.go
@@ -1,7 +1,0 @@
-package xilinx
-
-import (
-	"dbt-rules/RULES/xilinx"
-)
-
-var ExportSimulatorIp = xilinx.ExportSimulatorIp{}


### PR DESCRIPTION
Resolves #30 by deleting the build target from the rules. It should be added in the local projects as necessary instead.