### PR TITLE
Fixing missing space when using compiled libraries.

### DIFF
--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -98,9 +98,8 @@ func (rule Simulation) Instance() string {
 func (rule Simulation) libFlags() string {
 	flags := ""
 	if SimulatorLibDir.Value() != "" {
-		flags += fmt.Sprintf("-modelsimini %s/modelsim.ini", SimulatorLibDir.Value())
 		for _, lib := range rule.Libs {
-			flags += fmt.Sprintf(" -L %s", lib)
+			flags += fmt.Sprintf(" -L %s/%s", SimulatorLibDir.Value(), lib)
 		}
 	}
 


### PR DESCRIPTION
There is a missing space in the flags causing the `dbt test` to fail when doing gate-level simulations.