### PR TITLE
Improved flag handling

### DIFF
--- a/RULES/core/context.go
+++ b/RULES/core/context.go
@@ -51,15 +51,15 @@ type BuildStep struct {
 }
 
 type BuildRule struct {
-	Name string
+	Name      string
 	Variables map[string]string
 }
 
 type BuildStepWithRule struct {
-	Outs []OutPath
-	Ins  []Path
+	Outs      []OutPath
+	Ins       []Path
 	Variables map[string]string
-	Rule BuildRule 
+	Rule      BuildRule
 }
 
 func (step *BuildStep) outs() []OutPath {
@@ -107,8 +107,8 @@ type context struct {
 	bashFile     strings.Builder
 	nextRuleID   int
 
-	trace    []string
-	seenOnce map[string]bool
+	trace     []string
+	seenOnce  map[string]bool
 	seenRules map[string]bool
 }
 
@@ -122,7 +122,7 @@ func newContext(vars map[string]interface{}) *context {
 		ninjaFile:    strings.Builder{},
 		bashFile:     strings.Builder{},
 		seenOnce:     map[string]bool{},
-		seenRules:     map[string]bool{},
+		seenRules:    map[string]bool{},
 	}
 
 	for name := range vars {
@@ -201,7 +201,7 @@ func (ctx *context) AddBuildStep(step BuildStep) {
 		buffer := []byte(data)
 		hash := crc32.ChecksumIEEE([]byte(buffer))
 		dataFileName := fmt.Sprintf("%08X", hash)
-		dataFilePath = path.Join(filepath.Dir(buildDir()), "DATA", dataFileName)
+		dataFilePath = path.Join(filepath.Dir(input.OutputDir), "DATA", dataFileName)
 		if err := os.MkdirAll(filepath.Dir(dataFilePath), os.ModePerm); err != nil {
 			Fatal("Failed to create directory for data files: %s", err)
 		}
@@ -254,7 +254,7 @@ func (ctx *context) AddBuildStepWithRule(step BuildStepWithRule) {
 	if !ctx.seenRules[step.Rule.Name] {
 		ctx.seenRules[step.Rule.Name] = true
 		fmt.Fprintf(&ctx.ninjaFile, "rule %s\n", step.Rule.Name)
-		for name,value := range step.Rule.Variables {
+		for name, value := range step.Rule.Variables {
 			fmt.Fprintf(&ctx.ninjaFile, "  %s = %s\n", name, value)
 		}
 		fmt.Fprint(&ctx.ninjaFile, "\n")
@@ -262,7 +262,7 @@ func (ctx *context) AddBuildStepWithRule(step BuildStepWithRule) {
 
 	fmt.Fprintf(&ctx.ninjaFile, "# trace: %s\n", strings.Join(ctx.Trace(), " // "))
 	fmt.Fprintf(&ctx.ninjaFile, "build %s: %s %s\n", strings.Join(outs, " "), step.Rule.Name, strings.Join(ins, " "))
-	for name,value := range step.Variables {
+	for name, value := range step.Variables {
 		fmt.Fprintf(&ctx.ninjaFile, "  %s = %s\n", name, value)
 	}
 	fmt.Fprint(&ctx.ninjaFile, "\n\n")

--- a/RULES/core/main.go
+++ b/RULES/core/main.go
@@ -7,7 +7,7 @@ import (
 	"unicode"
 )
 
-const buildProtocolVersion = 2
+const buildProtocolVersion = 3
 const inputFileName = "input.json"
 const outputFileName = "output.json"
 
@@ -21,8 +21,9 @@ type generatorInput struct {
 	Version         uint
 	SourceDir       string
 	WorkingDir      string
-	BuildDirPrefix  string
-	BuildFlags      map[string]string
+	OutputDir       string
+	CmdlineFlags    map[string]string
+	WorkspaceFlags  map[string]string
 	CompletionsOnly bool
 	RunArgs         []string
 	TestArgs        []string
@@ -33,17 +34,15 @@ type generatorOutput struct {
 	NinjaFile string
 	Targets   map[string]targetInfo
 	Flags     map[string]flagInfo
-	BuildDir  string
 }
 
 var input = loadInput()
 
 func GeneratorMain(vars map[string]interface{}) {
 	output := generatorOutput{
-		Version:  buildProtocolVersion,
-		Targets:  map[string]targetInfo{},
-		Flags:    lockAndGetFlags(),
-		BuildDir: buildDir(),
+		Version: buildProtocolVersion,
+		Targets: map[string]targetInfo{},
+		Flags:   lockAndGetFlags(),
 	}
 
 	for targetPath, variable := range vars {

--- a/RULES/core/main.go
+++ b/RULES/core/main.go
@@ -7,7 +7,6 @@ import (
 	"unicode"
 )
 
-const buildProtocolVersion = 3
 const inputFileName = "input.json"
 const outputFileName = "output.json"
 
@@ -18,7 +17,7 @@ type targetInfo struct {
 }
 
 type generatorInput struct {
-	Version         uint
+	DbtVersion      version
 	SourceDir       string
 	WorkingDir      string
 	OutputDir       string
@@ -30,7 +29,6 @@ type generatorInput struct {
 }
 
 type generatorOutput struct {
-	Version   uint
 	NinjaFile string
 	Targets   map[string]targetInfo
 	Flags     map[string]flagInfo
@@ -40,7 +38,6 @@ var input = loadInput()
 
 func GeneratorMain(vars map[string]interface{}) {
 	output := generatorOutput{
-		Version: buildProtocolVersion,
 		Targets: map[string]targetInfo{},
 		Flags:   lockAndGetFlags(),
 	}

--- a/RULES/core/path.go
+++ b/RULES/core/path.go
@@ -64,7 +64,7 @@ type outPath struct {
 
 // Absolute returns the absolute path.
 func (p outPath) Absolute() string {
-	return path.Join(buildDir(), p.rel)
+	return path.Join(input.OutputDir, p.rel)
 }
 
 // Relative returns the path relative to the workspace build directory.

--- a/RULES/core/util.go
+++ b/RULES/core/util.go
@@ -12,9 +12,27 @@ import (
 	"text/template"
 )
 
+type version [3]uint
+
+func (v version) String() string {
+	return fmt.Sprintf("v%d.%d.%d", v[0], v[1], v[2])
+}
+
 const fileMode = 0755
 
 var currentTarget = ""
+
+var minDbtVersion = version{1, 2, 9}
+
+func checkVersion(curVersion, minVersion version) bool {
+	if curVersion[0] != minVersion[0] {
+		return curVersion[0] > minVersion[0]
+	}
+	if curVersion[1] != minVersion[1] {
+		return curVersion[1] > minVersion[1]
+	}
+	return curVersion[2] >= minVersion[2]
+}
 
 func loadInput() generatorInput {
 	data, err := ioutil.ReadFile(inputFileName)
@@ -22,15 +40,18 @@ func loadInput() generatorInput {
 		fmt.Fprintf(os.Stderr, "Error: Could not read DBT input file: %s.\n", err)
 		os.Exit(1)
 	}
+
 	var input generatorInput
 	if err := json.Unmarshal(data, &input); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Could not parse DBT input: %s.\n", err)
 		os.Exit(1)
 	}
-	if input.Version != buildProtocolVersion {
-		fmt.Fprintf(os.Stderr, "Error: Unexpected version of DBT input: %d. Expected %d.\n", input.Version, buildProtocolVersion)
+
+	if !checkVersion(input.DbtVersion, minDbtVersion) {
+		fmt.Fprintf(os.Stderr, "Error: dbt-rules require dbt >= %s, but have been called from dbt %s.\n", minDbtVersion, input.DbtVersion)
 		os.Exit(1)
 	}
+
 	return input
 }
 

--- a/RULES/core/util.go
+++ b/RULES/core/util.go
@@ -14,28 +14,7 @@ import (
 
 const fileMode = 0755
 
-var (
-	currentTarget  = ""
-	buildDirSuffix = ""
-)
-
-var outptuDir = StringFlag {
-	Name: "output-dir",
-	Description: "Output dir",
-	DefaultFn: func() string { return "" },
-}.Register()
-
-func buildDir() string {
-	if !flagsLocked {
-		Fatal("cannot use build directory before all flag values are known")
-	}
-
-	if outptuDir.Value() != "" {
-		return outptuDir.Value()
-	}
-
-	return input.BuildDirPrefix + buildDirSuffix
-}
+var currentTarget = ""
 
 func loadInput() generatorInput {
 	data, err := ioutil.ReadFile(inputFileName)


### PR DESCRIPTION
- the `ouputDir` is now passed from DBT, and no longer computed based on hashed flag values
- both command-line flags and workspace flags (from the `MODULE` file) are passed in by dbt. The different flag value sources are now considered in the following order: 1. command-line, 2. `FLAGS.json` file, 3. `MODULE` file, flag default. The current flag values are persisted (written to `FLAGS.json`) every time a dbt build is executed. There is one `FLAGS.json` file per output directory.