### PR TITLE
Small improvments to the CC rules + new mechanism to track rebuilds

### DIFF
--- a/RULES/cc/toolchain.go
+++ b/RULES/cc/toolchain.go
@@ -123,7 +123,7 @@ func (gcc GccToolchain) ObjcopyCommand() string {
 
 func (gcc GccToolchain) CFlags() []string {
 	result := gcc.CCompilerFlags
-	for _,inc := range(gcc.Includes) {
+	for _, inc := range gcc.Includes {
 		result = append(result, "-isystem", fmt.Sprintf("%q", inc))
 	}
 	return result
@@ -131,7 +131,7 @@ func (gcc GccToolchain) CFlags() []string {
 
 func (gcc GccToolchain) CxxFlags() []string {
 	result := gcc.CxxCompilerFlags
-	for _,inc := range(gcc.Includes) {
+	for _, inc := range gcc.Includes {
 		result = append(result, "-isystem", fmt.Sprintf("%q", inc))
 	}
 	return result

--- a/RULES/core/group.go
+++ b/RULES/core/group.go
@@ -1,9 +1,0 @@
-package core
-
-type TargetGroup []interface{}
-
-func (group TargetGroup) Build(ctx Context) {
-	for i := range group {
-		ctx.addTargetDependency(group[i])
-	}
-}

--- a/RULES/core/main.go
+++ b/RULES/core/main.go
@@ -75,7 +75,7 @@ func GeneratorMain(vars map[string]interface{}) {
 				ctx.handleTarget(targetPath, build)
 			}
 		}
-		output.NinjaFile = ctx.ninjaFile.String()
+		output.NinjaFile = ctx.ninjaFile()
 	}
 
 	// Serialize generator output.


### PR DESCRIPTION
This PR contains the following improvements for the CC rules:
- when compiling source files the resulting object files are no longer placed in a nested directory structure
- the `ctx.Built()` check to prevent multiple builds is no longer necessary, since the context keeps track of build steps automatically
- library dependencies are no longer built immediately, but only when a binary is built

There are also some changes to the DBT generator core:
- the `ctx.Built()` functionality has been removed. Instead multiple `Build()` calls for the same target are now properly handled by the context.
- the `addTargetDependency` mechanism (and the `Group` build rule have been removed. They were originally used to expose groups of targets (i.e. all unit tests) as a single target. However, it was never used and we can now (if ever needed) implement it much simpler by calling `Build()` on all targets in the group.
- the context new creates a `BuildStepWithRule` for each `AddBuildStep` / `AddBuildStepWithRule` invocation. For `AddBuildStep` a new anonymous rule is created. All build steps are collected and only output at the end. This allows collecting and printing all traces for each target. If some output is built multiple times (e.g. because `Build` has been called multiple times on a target producing that output), the context will compare the previous and the new build step building the output. If they are identical, the second build step is ignored (only the new trace is added to the previous build step). If they are different, the build fails.