### PR TITLE
Fixing dependency problem and adding support for VCD dumping

### DIFF
--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -47,6 +47,23 @@ var ShowTestCasesFile = core.BoolFlag{
 	Description: "Enable output of the file where testcases were found",
 }.Register()
 
+// DumpVcd enables outputting of all signals in the design to a VCD file
+var DumpVcd = core.BoolFlag{
+	Name: "hdl-dump-vcd",
+	DefaultFn: func() bool {
+		return false
+	},
+	Description: "Enable output of signals to a VCD file",
+}.Register()
+
+var DumpVcdFile = core.StringFlag{
+	Name:        "hdl-dump-vcd-file",
+	Description: "Path to the VCD file",
+	DefaultFn: func() string {
+		return "dump.vcd.gz"
+	},
+}.Register()
+
 type ParamMap map[string]map[string]string
 
 type Simulation struct {

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -88,11 +88,14 @@ func xsimCompileSrcs(ctx core.Context, rule Simulation,
 			cmd = tool + " " + cmd + " " + src.String() + " > /dev/null" +
 				" || { cat " + log.String() + "; rm " + log.String() + "; exit 1; }"
 
+			// Add the source file to the dependencies
+			deps = append(deps, src)
+
 			// Add the compilation command as a build step with the log file as the
 			// generated output
 			ctx.AddBuildStep(core.BuildStep{
 				Out:   log,
-				Ins:   append(deps, src),
+				Ins:   deps,
 				Cmd:   cmd,
 				Descr: fmt.Sprintf("%s: %s", tool, src.Relative()),
 			})


### PR DESCRIPTION
A problem was found when testing the newest dbt-rules where circular dependencies were generated by mistake. The root cause seems to have been in the way the dependencies were constructed as part of the `hdl` rules. The source file was not correctly added to the dependencies passed to the following modules because of an incorrect use of the `append` function. This PR fixes that problem.

In addition, the PR adds support for automatic dumping of waveforms in VCD format. This enables the use of open-source tools for waveform debugging and can free up the simulation licenses for other users while the waveforms are being evaluated.