### PR TITLE
Create interfaces for static source code analysis

### DIFF
--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -61,6 +61,26 @@ func (obj objectFile) asRule() core.BuildRule {
 	}
 }
 
+func (obj objectFile) flags(tc Toolchain) []string {
+	flags := []string{}
+	switch filepath.Ext(obj.Src.Absolute()) {
+	case ".cc":
+		flags = append(tc.CxxFlags(), obj.CxxFlags...)
+	case ".c":
+		flags = append(tc.CFlags(), obj.CFlags...)
+	case ".S":
+		flags = append(tc.AsFlags(), obj.AsFlags...)
+	default:
+		core.Fatal("Unknown source extension for cc toolchain '" + filepath.Ext(obj.Src.Absolute()) + "'")
+	}
+
+	for _,inc := range obj.Includes {
+		flags = append(flags, fmt.Sprintf("-I%s", inc.Absolute()))
+	}
+
+	return flags
+}
+
 // Build an objectFile.
 func (obj objectFile) Build(ctx core.Context) {
 	rule := core.BuildRule{}
@@ -207,7 +227,7 @@ func includesForSoruces(srcs []core.Path, private bool) []core.Path {
 	return result
 }
 
-func compileSources(out core.OutPath, ctx core.Context, srcs []core.Path, cFlags []string, cxxFlags []string, asFlags []string, deps []Library, includes []core.Path, toolchain Toolchain, orderDeps []core.Path) []core.Path {
+func getObjs(out core.OutPath, ctx core.Context, srcs []core.Path, cFlags []string, cxxFlags []string, asFlags []string, deps []Library, includes []core.Path, toolchain Toolchain, orderDeps []core.Path) []objectFile {
 	for _, dep := range deps {
 		includes = append(includes, dep.Includes...)
 		orderDeps = append(orderDeps, dep.GeneratedSrcs...)
@@ -216,10 +236,10 @@ func compileSources(out core.OutPath, ctx core.Context, srcs []core.Path, cFlags
 	includes = append(includes, includesForSoruces(srcs, true)...)
 	includes = append(includes, core.SourcePath(""))
 
-	objs := []core.Path{}
+	objs := []objectFile{}
 
 	for _, src := range srcs {
-		obj := objectFile{
+		objs = append(objs, objectFile{
 			Out:       out.WithSuffix(src.WithSuffix(".o").Relative()),
 			Src:       src,
 			OrderDeps: orderDeps,
@@ -228,7 +248,15 @@ func compileSources(out core.OutPath, ctx core.Context, srcs []core.Path, cFlags
 			CxxFlags:  cxxFlags,
 			AsFlags:   asFlags,
 			Toolchain: toolchain,
-		}
+		})
+	}
+
+	return objs
+}
+
+func compileSources(out core.OutPath, ctx core.Context, srcs []core.Path, cFlags []string, cxxFlags []string, asFlags []string, deps []Library, includes []core.Path, toolchain Toolchain, orderDeps []core.Path) []core.Path {
+	objs := []core.Path{}
+	for _, obj := range getObjs(out, ctx, srcs, cFlags, cxxFlags, asFlags, deps, includes, toolchain, orderDeps) {
 		obj.Build(ctx)
 		objs = append(objs, obj.Out)
 	}
@@ -265,6 +293,35 @@ type Library struct {
 	// Extra fields for handling multi-toolchain logic.
 	userOut       core.OutPath
 	userToolchain Toolchain
+}
+
+func (lib Library) Units(ctx core.Context) []core.TranslationUnit {
+	result := []core.TranslationUnit{}
+
+	toolchain := toolchainOrDefault(lib.Toolchain)
+	deps := collectDepsWithToolchain(toolchain, append(lib.Deps, toolchain.StdDeps()...))
+
+	objs := getObjs(lib.Out, ctx, append(lib.Srcs, lib.GeneratedSrcs...), lib.CFlags, lib.CxxFlags, lib.AsFlags, deps, lib.Includes, toolchain, lib.GeneratedSrcs)
+
+	for _,obj := range objs {
+		result = append(result, core.TranslationUnit{
+			Source: obj.Src,
+			Object: obj.Out,
+			Flags: obj.flags(toolchain),
+		})
+
+	}
+
+	return result
+}
+
+func (lib Library) EnumerateDeps(ctx core.Context) []core.AnalyzeInterface {
+	result := []core.AnalyzeInterface{}
+	toolchain := toolchainOrDefault(lib.Toolchain)
+	for _,dep := range lib.Deps {
+		result = append(result, dep.CcLibrary(toolchain))
+	}
+	return result
 }
 
 func (lib Library) arRule() core.BuildRule {

--- a/RULES/core/context.go
+++ b/RULES/core/context.go
@@ -105,6 +105,23 @@ type coverageReportInterface interface {
 	Build(ctx Context)
 }
 
+type TranslationUnit struct {
+	Source Path
+	Object OutPath
+	Flags []string
+}
+
+// AnalyzeInterface is an interface for targets cpmpatible with static analisys
+type AnalyzeInterface interface {
+	Units(ctx Context) []TranslationUnit
+	EnumerateDeps(ctx Context) []AnalyzeInterface
+}
+
+type analyzeReportInterface interface {
+	AnalyzeReport(targets []AnalyzeInterface) interface{}
+	Build(ctx Context)
+}
+
 type context struct {
 	cwd         OutPath
 	nextRuleID  int

--- a/RULES/core/main.go
+++ b/RULES/core/main.go
@@ -84,6 +84,7 @@ func GeneratorMain(vars map[string]interface{}) {
 		sort.Strings(targetPaths)
 
 		var targetsForCoverage = []CoverageInterface{}
+		var targetsForAnalyze = []AnalyzeInterface{}
 
 		for _, targetPath := range targetPaths {
 			tgt := vars[targetPath]
@@ -100,12 +101,18 @@ func GeneratorMain(vars map[string]interface{}) {
 				}
 				targetsForCoverage = append(targetsForCoverage, cov)
 			}
+			if sa, ok := tgt.(AnalyzeInterface); ok {
+				targetsForAnalyze = append(targetsForAnalyze, sa)
+			}
 		}
 
 		for _, targetPath := range targetPaths {
 			tgt := vars[targetPath]
 			if build, ok := tgt.(coverageReportInterface); ok {
 				tgt = build.CoverageReport(targetsForCoverage)
+			}
+			if build, ok := tgt.(analyzeReportInterface); ok {
+				tgt = build.AnalyzeReport(targetsForAnalyze)
 			}
 
 			if build, ok := tgt.(buildInterface); ok {


### PR DESCRIPTION
In order to use static source code tools, these will need to know the translation units  and internal compilation details. These changes add the `TranslationUnit`, `AnalyzeInterface` and `analyzeReportInterface` for such tools and makes it possible to list translation units and for a `cc.Binary` or `cc.Library` and its dependencies.

These changes are already being used in exp-utest, but I would like to merge them (with proper review) and create a release before using them in prod.

Authorship of these changes belongs to Nikolai Filchenko @finomen 