### PR TITLE
Create interfaces for static source code analysis

### DIFF
--- a/RULES/cc/cc.go
+++ b/RULES/cc/cc.go
@@ -74,7 +74,7 @@ func (obj objectFile) flags(tc Toolchain) []string {
 		core.Fatal("Unknown source extension for cc toolchain '" + filepath.Ext(obj.Src.Absolute()) + "'")
 	}
 
-	for _,inc := range obj.Includes {
+	for _, inc := range obj.Includes {
 		flags = append(flags, fmt.Sprintf("-I%s", inc.Absolute()))
 	}
 
@@ -295,7 +295,7 @@ type Library struct {
 	userToolchain Toolchain
 }
 
-func (lib Library) Units(ctx core.Context) []core.TranslationUnit {
+func (lib Library) TranslationUnits(ctx core.Context) []core.TranslationUnit {
 	result := []core.TranslationUnit{}
 
 	toolchain := toolchainOrDefault(lib.Toolchain)
@@ -303,11 +303,11 @@ func (lib Library) Units(ctx core.Context) []core.TranslationUnit {
 
 	objs := getObjs(lib.Out, ctx, append(lib.Srcs, lib.GeneratedSrcs...), lib.CFlags, lib.CxxFlags, lib.AsFlags, deps, lib.Includes, toolchain, lib.GeneratedSrcs)
 
-	for _,obj := range objs {
+	for _, obj := range objs {
 		result = append(result, core.TranslationUnit{
 			Source: obj.Src,
 			Object: obj.Out,
-			Flags: obj.flags(toolchain),
+			Flags:  obj.flags(toolchain),
 		})
 
 	}
@@ -315,10 +315,10 @@ func (lib Library) Units(ctx core.Context) []core.TranslationUnit {
 	return result
 }
 
-func (lib Library) EnumerateDeps(ctx core.Context) []core.AnalyzeInterface {
+func (lib Library) AnalysisDeps(ctx core.Context) []core.AnalyzeInterface {
 	result := []core.AnalyzeInterface{}
 	toolchain := toolchainOrDefault(lib.Toolchain)
-	for _,dep := range lib.Deps {
+	for _, dep := range lib.Deps {
 		result = append(result, dep.CcLibrary(toolchain))
 	}
 	return result
@@ -471,8 +471,7 @@ type Binary struct {
 	Includes    []core.Path
 }
 
-
-func (bin Binary) Units(ctx core.Context) []core.TranslationUnit {
+func (bin Binary) TranslationUnits(ctx core.Context) []core.TranslationUnit {
 	result := []core.TranslationUnit{}
 
 	toolchain := toolchainOrDefault(bin.Toolchain)
@@ -480,11 +479,11 @@ func (bin Binary) Units(ctx core.Context) []core.TranslationUnit {
 
 	objs := getObjs(bin.Out, ctx, bin.Srcs, bin.CFlags, bin.CxxFlags, bin.AsFlags, deps, bin.Includes, toolchain, []core.Path{})
 
-	for _,obj := range objs {
+	for _, obj := range objs {
 		result = append(result, core.TranslationUnit{
 			Source: obj.Src,
 			Object: obj.Out,
-			Flags: obj.flags(toolchain),
+			Flags:  obj.flags(toolchain),
 		})
 
 	}
@@ -492,10 +491,10 @@ func (bin Binary) Units(ctx core.Context) []core.TranslationUnit {
 	return result
 }
 
-func (bin Binary) EnumerateDeps(ctx core.Context) []core.AnalyzeInterface {
+func (bin Binary) AnalysisDeps(ctx core.Context) []core.AnalyzeInterface {
 	result := []core.AnalyzeInterface{}
 	toolchain := toolchainOrDefault(bin.Toolchain)
-	for _,dep := range bin.Deps {
+	for _, dep := range bin.Deps {
 		result = append(result, dep.CcLibrary(toolchain))
 	}
 	return result

--- a/RULES/core/context.go
+++ b/RULES/core/context.go
@@ -105,6 +105,23 @@ type coverageReportInterface interface {
 	Build(ctx Context)
 }
 
+type TranslationUnit struct {
+	Source Path
+	Object OutPath
+	Flags []string
+}
+
+// AnalyzeInterface is an interface for targets cpmpatible with static analisys
+type AnalyzeInterface interface {
+	Units(ctx Context) []TranslationUnit
+	EnumerateDeps(ctx Context) []AnalyzeInterface
+}
+
+type analyzeReportInterface interface {
+	AnalyzeReport(targets []AnalyzeInterface) interface{}
+	Build(ctx Context)
+}
+
 type context struct {
 	cwd         OutPath
 	nextRuleID  int

--- a/RULES/core/context.go
+++ b/RULES/core/context.go
@@ -108,16 +108,16 @@ type coverageReportInterface interface {
 type TranslationUnit struct {
 	Source Path
 	Object OutPath
-	Flags []string
+	Flags  []string
 }
 
-// AnalyzeInterface is an interface for targets cpmpatible with static analisys
+// AnalyzeInterface is an interface for targets compatible with static analisys
 type AnalyzeInterface interface {
-	Units(ctx Context) []TranslationUnit
-	EnumerateDeps(ctx Context) []AnalyzeInterface
+	TranslationUnits(ctx Context) []TranslationUnit
+	AnalysisDeps(ctx Context) []AnalyzeInterface
 }
 
-type analyzeReportInterface interface {
+type analyzerReportInterface interface {
 	AnalyzeReport(targets []AnalyzeInterface) interface{}
 	Build(ctx Context)
 }

--- a/RULES/core/main.go
+++ b/RULES/core/main.go
@@ -84,6 +84,7 @@ func GeneratorMain(vars map[string]interface{}) {
 		sort.Strings(targetPaths)
 
 		var targetsForCoverage = []CoverageInterface{}
+		var targetsForAnalyze = []AnalyzeInterface{}
 
 		for _, targetPath := range targetPaths {
 			tgt := vars[targetPath]
@@ -100,12 +101,18 @@ func GeneratorMain(vars map[string]interface{}) {
 				}
 				targetsForCoverage = append(targetsForCoverage, cov)
 			}
+			if sa, ok := tgt.(AnalyzeInterface); ok {
+				targetsForAnalyze = append(targetsForAnalyze, sa)
+			}
 		}
 
 		for _, targetPath := range targetPaths {
 			tgt := vars[targetPath]
 			if build, ok := tgt.(coverageReportInterface); ok {
 				tgt = build.CoverageReport(targetsForCoverage)
+			}
+			if build, ok := tgt.(analyzeReportInterface); ok {
+				tgt = build.AnalyzeReport(targetsForAnalyze)
 			}
 
 			if build, ok := tgt.(buildInterface); ok {

--- a/RULES/core/main.go
+++ b/RULES/core/main.go
@@ -15,7 +15,7 @@ type targetInfo struct {
 	Description string
 	Runnable    bool
 	Testable    bool
-	Report		bool
+	Report      bool
 }
 
 type generatorInput struct {
@@ -29,7 +29,7 @@ type generatorInput struct {
 	RunArgs         []string
 	TestArgs        []string
 	Layout          string
-	SelectedTargets        []string
+	SelectedTargets []string
 }
 
 type generatorOutput struct {
@@ -39,8 +39,6 @@ type generatorOutput struct {
 }
 
 var input = loadInput()
-
-
 
 func GeneratorMain(vars map[string]interface{}) {
 	output := generatorOutput{
@@ -90,7 +88,7 @@ func GeneratorMain(vars map[string]interface{}) {
 			tgt := vars[targetPath]
 			if cov, ok := tgt.(CoverageInterface); ok {
 				var selected = false
-				for _,path := range input.SelectedTargets {
+				for _, path := range input.SelectedTargets {
 					if path == targetPath {
 						selected = true
 						break

--- a/RULES/core/main.go
+++ b/RULES/core/main.go
@@ -111,7 +111,7 @@ func GeneratorMain(vars map[string]interface{}) {
 			if build, ok := tgt.(coverageReportInterface); ok {
 				tgt = build.CoverageReport(targetsForCoverage)
 			}
-			if build, ok := tgt.(analyzeReportInterface); ok {
+			if build, ok := tgt.(analyzerReportInterface); ok {
 				tgt = build.AnalyzeReport(targetsForAnalyze)
 			}
 


### PR DESCRIPTION
In order to use static source code tools, these will need to know the translation units and internal compilation details. These changes add the TranslationUnit, AnalyzeInterface and analyzeReportInterface for such tools and makes it possible to list translation units and for a cc.Binary or cc.Library and its dependencies.

These changes are already being used in exp-utest, but I would like to merge them (with proper review) and create a release before using them in prod.

Authorship of these changes belongs to Nikolai Filchenko @finomen

This is a followup of #82 