### PR TITLE
Adding support for defines and -to=<time> option

### DIFF
--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -144,7 +144,11 @@ vcd file {{ .DumpVcdFile }}
 vcd add -r *
 {{ end }}
 
-run -all
+if [info exists until] {
+	run $until
+} else {
+	run -all
+}
 
 {{ if .DumpVcd }}
 vcd flush
@@ -512,6 +516,14 @@ func questaCmd(rule Simulation, args []string, gui bool, testcase string, params
 			} else {
 				log.Fatal("-verbosity expects an argument of 'low', 'medium', 'high' or 'none'!")
 			}
+		} else if strings.HasPrefix(arg, "-until=") {
+				// Define how long to run
+				var until string
+				if _, err := fmt.Sscanf(arg, "-until=%s", &until); err == nil {
+					do_flags = append(do_flags, fmt.Sprintf("\"set until %s\""), until)
+				} else {
+					log.Fatal("-until expects an argument of '<timesteps>[<time units>]'!")
+				}
 		} else if strings.HasPrefix(arg, "+") {
 			// All '+' arguments go directly to the simulator
 			plusargs_flag = plusargs_flag + " " + arg

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -205,6 +205,12 @@ func compileSrcs(ctx core.Context, rule Simulation,
 						cmd = cmd + " " + vlog_flags
 					}
 				}
+				for key, value := rule.Defines {
+					cmd = cmd + fmt.Sprintf(" -define %s", key)
+					if value != "" {
+						cmd = cmd + fmt.Sprintf("=%s", value)
+					}
+				}
 			} else if IsVhdl(src.String()) {
 				tool = "vcom"
 				cmd = cmd + " " + VcomFlags.Value()

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -195,7 +195,7 @@ func compileSrcs(ctx core.Context, rule Simulation,
 			if IsVerilog(src.String()) {
 				tool = "vlog"
 				cmd = cmd + " " + VlogFlags.Value()
-				cmd = cmd + " -suppress 2583 -svinputport=net"
+				cmd = cmd + " -suppress 2583 -svinputport=net -define SIMULATION"
 				cmd = cmd + fmt.Sprintf(" +incdir+%s", core.SourcePath("").String())
 				for _, inc := range incs {
 					cmd = cmd + fmt.Sprintf(" +incdir+%s", path.Dir(inc.Absolute()))
@@ -393,7 +393,7 @@ func doFile(ctx core.Context, rule Simulation) {
 	params := DoFileParams{
 		Lib: rule.Lib(),
 		DumpVcd: DumpVcd.Value(),
-		DumpVcdFile: DumpVcdFile.Value(),
+		DumpVcdFile: fmt.Sprintf("%s.vcd.gz", rule.Name),
 	}
 
 	if rule.WaveformInit != nil {

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -205,7 +205,7 @@ func compileSrcs(ctx core.Context, rule Simulation,
 						cmd = cmd + " " + vlog_flags
 					}
 				}
-				for key, value := rule.Defines {
+				for key, value := range rule.Defines {
 					cmd = cmd + fmt.Sprintf(" -define %s", key)
 					if value != "" {
 						cmd = cmd + fmt.Sprintf("=%s", value)
@@ -526,7 +526,7 @@ func questaCmd(rule Simulation, args []string, gui bool, testcase string, params
 				// Define how long to run
 				var until string
 				if _, err := fmt.Sscanf(arg, "-until=%s", &until); err == nil {
-					do_flags = append(do_flags, fmt.Sprintf("\"set until %s\""), until)
+					do_flags = append(do_flags, fmt.Sprintf("\"set until %s\"", until))
 				} else {
 					log.Fatal("-until expects an argument of '<timesteps>[<time units>]'!")
 				}

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -149,7 +149,7 @@ vcd add -r *
 {{ end }}
 
 if [info exists to] {
-	run $to
+	run @$to
 } else {
 	run -all
 }

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -56,14 +56,6 @@ var DumpVcd = core.BoolFlag{
 	Description: "Enable output of signals to a VCD file",
 }.Register()
 
-var DumpVcdFile = core.StringFlag{
-	Name:        "hdl-dump-vcd-file",
-	Description: "Path to the VCD file",
-	DefaultFn: func() string {
-		return "dump.vcd.gz"
-	},
-}.Register()
-
 type ParamMap map[string]map[string]string
 type DefineMap map[string]string
 

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -73,6 +73,7 @@ type Simulation struct {
 	Ips                    []Ip
 	Libs                   []string
 	Params                 ParamMap
+	Defines                DefineMap
 	ToolFlags              FlagMap
 	Top                    string
 	Tops                   []string

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -65,6 +65,7 @@ var DumpVcdFile = core.StringFlag{
 }.Register()
 
 type ParamMap map[string]map[string]string
+type DefineMap map[string]string
 
 type Simulation struct {
 	Name                   string

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -74,10 +74,16 @@ func xsimCompileSrcs(ctx core.Context, rule Simulation,
 			var tool string
 			if IsVerilog(src.String()) {
 				tool = "xvlog"
-				cmd = cmd + " --sv " + XvlogFlags.Value()
+				cmd = cmd + " --sv --define SIMULATION" + XvlogFlags.Value()
 				cmd = cmd + fmt.Sprintf(" -i %s", core.SourcePath("").String())
 				for _, inc := range incs {
 					cmd = cmd + fmt.Sprintf(" -i %s", path.Dir(inc.Absolute()))
+				}
+				for key, value := rule.Defines {
+					cmd = cmd + fmt.Sprintf(" --define %s", key)
+					if value != "" {
+						cmd = cmd + fmt.Sprintf("=%s", value)
+					}
 				}
 			} else if IsVhdl(src.String()) {
 				tool = "xvhdl"

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -79,7 +79,7 @@ func xsimCompileSrcs(ctx core.Context, rule Simulation,
 				for _, inc := range incs {
 					cmd = cmd + fmt.Sprintf(" -i %s", path.Dir(inc.Absolute()))
 				}
-				for key, value := rule.Defines {
+				for key, value := range rule.Defines {
 					cmd = cmd + fmt.Sprintf(" --define %s", key)
 					if value != "" {
 						cmd = cmd + fmt.Sprintf("=%s", value)


### PR DESCRIPTION
When debugging a simulation using VCD and batch-mode simulation it is often useful to be able to start waveform dumping and stop the simulation close to an error. This change adds the command line options `-from=<time><scale>` and `-to=<time><scale>` for that purpose (e.g. `-to=1us`). It will then run the simulation until the argument given to `from`, start dumping VCD information and then run the simulation until the absolute time given by `to` and optionally exit (if in batch mode).

In addition, this change adds the field `Defines` to the `Simulation` target for specifying additional Verilog defines for controlling e.g. the specifics of a simulation. Currently, the define `SIMULATION` has been added by default, which could be used for e.g. disabling the inclusion of assertions in code for synthesis.