### PR TITLE
Updated with textual code coverage report and improved xsim support.

### DIFF
--- a/RULES/hdl/hdl.go
+++ b/RULES/hdl/hdl.go
@@ -25,6 +25,7 @@ type Ip interface {
 	Data() []core.Path
 	Ips() []Ip
 	Flags() FlagMap
+	ReportCovFiles() []string
 }
 
 type Library struct {
@@ -33,6 +34,7 @@ type Library struct {
 	DataFiles []core.Path
 	IpDeps    []Ip
 	ToolFlags FlagMap
+	ReportCov bool
 }
 
 func (lib Library) Sources() []core.Path {
@@ -49,4 +51,17 @@ func (lib Library) Ips() []Ip {
 
 func (lib Library) Flags() FlagMap {
 	return lib.ToolFlags
+}
+
+func (lib Library) ReportCovFiles() []string {
+	files := []string{}
+	if lib.ReportCov {
+		for _, src := range lib.Srcs {
+			files = append(files, src.Absolute())
+		}
+	}
+	for _, ip := range lib.IpDeps {
+		files = append(files, ip.ReportCovFiles()...)
+	}
+	return files
 }

--- a/RULES/hdl/hdl.go
+++ b/RULES/hdl/hdl.go
@@ -1,6 +1,8 @@
 package hdl
 
 import (
+	"reflect"
+
 	"dbt-rules/RULES/core"
 )
 
@@ -63,5 +65,19 @@ func (lib Library) ReportCovFiles() []string {
 	for _, ip := range lib.IpDeps {
 		files = append(files, ip.ReportCovFiles()...)
 	}
-	return files
+
+	// Remove duplicates
+	set := make(map[string]bool)
+	for _, file := range files {
+		set[file] = true
+	}
+
+	// Convert back to string list
+	keys := reflect.ValueOf(set).MapKeys()
+	str_keys := make([]string, len(keys))
+	for i := 0; i < len(keys); i++ {
+		str_keys[i] = keys[i].String()
+	}
+
+	return str_keys
 }

--- a/RULES/hdl/hdl.go
+++ b/RULES/hdl/hdl.go
@@ -1,8 +1,6 @@
 package hdl
 
 import (
-	"reflect"
-
 	"dbt-rules/RULES/core"
 )
 
@@ -27,7 +25,6 @@ type Ip interface {
 	Data() []core.Path
 	Ips() []Ip
 	Flags() FlagMap
-	ReportCovFiles() []string
 }
 
 type Library struct {
@@ -36,7 +33,6 @@ type Library struct {
 	DataFiles []core.Path
 	IpDeps    []Ip
 	ToolFlags FlagMap
-	ReportCov bool
 }
 
 func (lib Library) Sources() []core.Path {
@@ -53,31 +49,4 @@ func (lib Library) Ips() []Ip {
 
 func (lib Library) Flags() FlagMap {
 	return lib.ToolFlags
-}
-
-func (lib Library) ReportCovFiles() []string {
-	files := []string{}
-	if lib.ReportCov {
-		for _, src := range lib.Srcs {
-			files = append(files, src.Absolute())
-		}
-	}
-	for _, ip := range lib.IpDeps {
-		files = append(files, ip.ReportCovFiles()...)
-	}
-
-	// Remove duplicates
-	set := make(map[string]bool)
-	for _, file := range files {
-		set[file] = true
-	}
-
-	// Convert back to string list
-	keys := reflect.ValueOf(set).MapKeys()
-	str_keys := make([]string, len(keys))
-	for i := 0; i < len(keys); i++ {
-		str_keys[i] = keys[i].String()
-	}
-
-	return str_keys
 }

--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -119,6 +119,7 @@ type DoFileParams struct {
 	WaveformInit string
 	DumpVcd      bool
 	DumpVcdFile  string
+	CovFiles     string
 }
 
 // Do-file template
@@ -169,7 +170,15 @@ if [info exists coverage] {
 	# Create HTML coverage report
 	vcover report -html -output ${main_coverage_db}_covhtml \
 		-testdetails -details -assert -directive -cvg -codeAll $main_coverage_db.ucdb
-	# Create textual coverage report
+	# Create textual code coverage report
+	{{ if .CovFiles }}
+	vcover report -output ${main_coverage_db}_covcode.txt -srcfile={{ .CovFiles }}\
+		-codeAll $main_coverage_db.ucdb
+	{{ else }}
+	vcover report -output ${main_coverage_db}_covcode.txt\
+		-codeAll $main_coverage_db.ucdb
+	{{ end }}
+	# Create textual assertion coverage report
 	puts "Writing coverage report to [pwd]/${main_coverage_db}_cover.txt"
 	vcover report -output ${main_coverage_db}_cover.txt -flat -directive -cvg $main_coverage_db.ucdb
 	# Create textural assertion report
@@ -403,6 +412,7 @@ func doFile(ctx core.Context, rule Simulation) {
 		Lib: rule.Lib(),
 		DumpVcd: DumpVcd.Value(),
 		DumpVcdFile: fmt.Sprintf("%s.vcd.gz", rule.Name),
+		CovFiles: strings.Join(rule.ReportCovFiles(), "+"),
 	}
 
 	if rule.WaveformInit != nil {

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -253,3 +253,11 @@ func Preamble(rule Simulation, testcase string) (string, string) {
 
 	return preamble, testcase
 }
+
+func (rule Simulation) ReportCovFiles() []string {
+	files := []string{}
+	for _, ip := range rule.Ips {
+		files = append(files, ip.ReportCovFiles()...)
+	}
+	return files
+}

--- a/RULES/hdl/simulator.go
+++ b/RULES/hdl/simulator.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"reflect"
 	"strings"
 )
 
@@ -75,6 +76,7 @@ type Simulation struct {
 	TestCaseElf            core.Path
 	TestCasesDir           core.Path
 	WaveformInit           core.Path
+	ReportCovIps           []Ip
 }
 
 // Lib returns the standard library name defined for this rule.
@@ -201,6 +203,31 @@ func (rule Simulation) Description() string {
 	return description
 }
 
+func (rule Simulation) ReportCovFiles() []string {
+	files := []string{}
+
+	for _, ip := range rule.ReportCovIps {
+		for _, src := range ip.Sources() {
+			files = append(files, src.String())
+		}
+	}
+
+	// Remove duplicates
+	set := make(map[string]bool)
+	for _, file := range files {
+		set[file] = true
+	}
+
+	// Convert back to string list
+	keys := reflect.ValueOf(set).MapKeys()
+	str_keys := make([]string, len(keys))
+	for i := 0; i < len(keys); i++ {
+		str_keys[i] = keys[i].String()
+	}
+
+	return str_keys
+}
+
 // Preamble creates a preamble for the simulation command for the purpose of generating
 // a testcase.
 func Preamble(rule Simulation, testcase string) (string, string) {
@@ -252,12 +279,4 @@ func Preamble(rule Simulation, testcase string) (string, string) {
 	}
 
 	return preamble, testcase
-}
-
-func (rule Simulation) ReportCovFiles() []string {
-	files := []string{}
-	for _, ip := range rule.Ips {
-		files = append(files, ip.ReportCovFiles()...)
-	}
-	return files
 }

--- a/RULES/hdl/utils.go
+++ b/RULES/hdl/utils.go
@@ -16,13 +16,18 @@ func IsVerilog(path string) bool {
 		strings.HasSuffix(path, ".sv")
 }
 
+func IsSystemVerilog(path string) bool {
+	return strings.HasSuffix(path, ".sv")
+}
+
 func IsVhdl(path string) bool {
 	return strings.HasSuffix(path, ".vhdl") ||
 		strings.HasSuffix(path, ".vhd")
 }
 
 func IsHeader(path string) bool {
-	return strings.HasSuffix(path, ".svh")
+	return strings.HasSuffix(path, ".vh") ||
+		strings.HasSuffix(path, ".svh")
 }
 
 func IsConstraint(path string) bool {

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -105,17 +105,6 @@ func addToPrjFile(ctx core.Context, prj prjFile, ips []Ip, srcs []core.Path) prj
 				prj.Incs = append(prj.Incs, new_path)
 				xsim_rules[new_path] = true
 			}
-			/*
-			gotit := false
-			for _, old_path := range prj.Incs {
-				if new_path == old_path {
-					gotit = true
-					break
-				}
-			}
-			if !gotit {
-			}
-			*/
 		} else if IsRtl(src.String()) {
 			if xsim_rules[src.String()] {
 				continue
@@ -354,7 +343,6 @@ func xsimCmd(rule Simulation, args []string, gui bool, testcase string, params s
 	xsim_cmd := []string{
 		"xsim",
 		"--log", log_file.String(),
-		"--wdb", wdb_file.String(),
 		"--tclbatch", do_file.String(),
 		XsimFlags.Value()}
 	verbosity_level := "none"
@@ -428,6 +416,11 @@ func xsimCmd(rule Simulation, args []string, gui bool, testcase string, params s
 		} else {
 			testcase = "default"
 		}
+	}
+
+	// Optionally specify waveform data file
+	if gui || XsimDumpWdb.Value() {
+		xsim_cmd = append(xsim_cmd, "--wdb", wdb_file.String())
 	}
 
 	cmd_postamble := ""

--- a/RULES/xilinx/sim_ip_export.go
+++ b/RULES/xilinx/sim_ip_export.go
@@ -34,9 +34,10 @@ type ExportSimulatorIp struct {
 }
 
 func (rule ExportSimulatorIp) Build(ctx core.Context) {
-	if hdl.Simulator.Value() != "questa" {
+	if hdl.Simulator.Value() == "xsim" {
+		// The simulation libraries do not have to be compiled for the xsim simulator
+		// as they are part of the tool installation directory
 		return
-		//core.Fatal("Simulator %s not supported!", hdl.Simulator.Value())
 	}
 
 	simLibs := hdl.SimulatorLibDir.Value()

--- a/RULES/xilinx/sim_ip_export.go
+++ b/RULES/xilinx/sim_ip_export.go
@@ -35,7 +35,8 @@ type ExportSimulatorIp struct {
 
 func (rule ExportSimulatorIp) Build(ctx core.Context) {
 	if hdl.Simulator.Value() != "questa" {
-		core.Fatal("Simulator %s not supported!", hdl.Simulator.Value())
+		return
+		//core.Fatal("Simulator %s not supported!", hdl.Simulator.Value())
 	}
 
 	simLibs := hdl.SimulatorLibDir.Value()


### PR DESCRIPTION
# Code coverage
For sign-off purposes it is useful to have a textual code coverage available to append to the design. This PR adds that functionality, but also extends the Library definition with a boolean element `ReportCov`, which can be used to limit the reporting to specific files. The idea is to be able to create a coverage report for only the files associated with a specific library, but also to ignore e.g. files associated only with verification.

# Xsim
The `xsim` support has also been improved such that compilation is now much faster, which was achieved by switching to using a project file listing all source files and removing the explicit compilation of each source file individually. In addition, the flow was also updated to support the VCD dumping functionality, starting the GUI as well as the `-to` and `-duration` flags to control a batch simulation.

