### PR TITLE
Add CompDbRules as outputs of the generator

### DIFF
--- a/RULES/core/main.go
+++ b/RULES/core/main.go
@@ -33,9 +33,10 @@ type generatorInput struct {
 }
 
 type generatorOutput struct {
-	NinjaFile string
-	Targets   map[string]targetInfo
-	Flags     map[string]flagInfo
+	NinjaFile   string
+	Targets     map[string]targetInfo
+	Flags       map[string]flagInfo
+	CompDbRules []string
 }
 
 var input = loadInput()
@@ -137,6 +138,11 @@ func GeneratorMain(vars map[string]interface{}) {
 			}
 		}
 		output.NinjaFile = ctx.ninjaFile()
+
+		output.CompDbRules = []string{}
+		for name := range ctx.compDbBuildRules {
+			output.CompDbRules = append(output.CompDbRules, name)
+		}
 	}
 
 	// Serialize generator output.


### PR DESCRIPTION
So that dbt can create a more fine-grained compilation database that does not confuse IDE's and tools like reqtraq