### PR TITLE
Fix analyzer targets reported as available when no buildAnalyzerTarge…

### DIFF
--- a/RULES/core/main.go
+++ b/RULES/core/main.go
@@ -98,7 +98,9 @@ func GeneratorMain(vars map[string]interface{}) {
 		if _, ok := variable.(coverageReportInterface); ok {
 			info.Report = true
 		}
-		output.Targets[targetPath] = info
+		if !isAnalyzerReportTarget(variable) || input.BuildAnalyzerTargets {
+			output.Targets[targetPath] = info
+		}
 	}
 
 	hasAnySelectedTargetsOtherThanReports := checkHasAnySelectedTargetsOtherThanReports(vars)


### PR DESCRIPTION
…ts == false

otherwise they can be used by a glob (e.g.: `//utest/.*`) and the build would fail saying that the target does not exist.