### PR TITLE
Add verbosity level ALL.

### DIFF
--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -481,9 +481,12 @@ func verbosityLevelToFlag(level string) (string, bool) {
 	case "high":
 		verbosity_flag = " +verbosity=DVM_VERB_HIGH"
 		print_output = true
+	case "all":
+		verbosity_flag = " +verbosity=DVM_VERB_ALL"
+		print_output = true
 	default:
 		log.Fatal(fmt.Sprintf("invalid verbosity flag '%s', only 'low', 'medium',"+
-			" 'high' or 'none' allowed!", level))
+			" 'high', 'all'  or 'none' allowed!", level))
 	}
 
 	return verbosity_flag, print_output

--- a/RULES/hdl/xsim.go
+++ b/RULES/hdl/xsim.go
@@ -303,9 +303,12 @@ func xsimVerbosityLevelToFlag(level string) (string, bool) {
 	case "high":
 		verbosity_flag = " --testplusarg verbosity=DVM_VERB_HIGH"
 		print_output = true
+	case "all":
+		verbosity_flag = "--testplusarg verbosity=DVM_VERB_ALL"
+		print_output = true
 	default:
 		log.Fatal(fmt.Sprintf("invalid verbosity flag '%s', only 'low', 'medium',"+
-			" 'high' or 'none' allowed!", level))
+			" 'high', 'all' or 'none' allowed!", level))
 	}
 
 	return verbosity_flag, print_output


### PR DESCRIPTION
Add additional flag value to set the log verbosity to the new value.

The new verbosity level `ALL` will replace the usecase of the previous `HIGH`, printing absolutely everything, including passed checks which is not useful for debugging.
This frees up `HIGH` to log detailed debug messages. 

Prerequisite to landing D14213.