### PR TITLE
Fixing warnings from standard libraries.

### DIFF
--- a/RULES/hdl/questa.go
+++ b/RULES/hdl/questa.go
@@ -133,6 +133,9 @@ proc reload {} {
 
 }
 
+set StdArithNoWarnings 1
+set NumericStdNoWarnings 1
+
 {{ if .WaveformInit }}
 if [info exists gui] {
 	source {{ .WaveformInit }}


### PR DESCRIPTION
Adds some options in the TCL file to quiet down warnings from Xilinx IPs.